### PR TITLE
auto-update:  brave(1.90.121)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.89.145
+version=1.90.121
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ maintainer="David Ivashevich <davidivashevich@gmail.com>"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=e9069992b7857c99be7b8395c1ff0c0a9cb987414a3b18739f4ca1e659b7b681
+checksum=565cd303d3dea5f2e42b1eb74627571fff9e832430329f489d86d7f0892b02e9
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-05-08

### Updated packages
- brave(1.90.121)

### ⚠️ Failed updates
- telegram-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.