### PR TITLE
auto-update:  helium-browser(0.12.1.1) telegram-bin(6.8.1)

### DIFF
--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.11.5.1
+version=0.12.1.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=362ec867d50169fafeb2cd017106912aa9a5989238215d6344027c8e17287658 
+checksum=f9413e26a42dc5b039b333ef02885aa579444b6d5504e74db15e848f575145fb
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=6.7.8
+version=6.8.1
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=17c7c16014975f0643b90c8c8fb419efd2f57c952b2153bee81390473108ce48
+checksum=5a8192dbb7df71995cae7d6aa25468fbf00a05cd5a54273a24e0fe077dc16002
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-05-08

### Updated packages
- helium-browser(0.12.1.1)
- telegram-bin(6.8.1)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.