### PR TITLE
auto-update:  bitwarden-bin(2026.4.0) brave(1.90.124) helium-browser(0.12.4.1)

### DIFF
--- a/srcpkgs/bitwarden-bin/template
+++ b/srcpkgs/bitwarden-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitwarden-bin'
 pkgname=bitwarden-bin
 _pkgname=bitwarden
-version=2026.3.1
+version=2026.4.0
 revision=1
 hostmakedepends="tar xz"
 short_desc="Bitwarden desktop client"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://bitwarden.com"
 distfiles="https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-amd64.deb"
-checksum=41df25b79e61381463d3901347c7a2927874d8229a174efdbac5b9115f184e40 
+checksum=bdd4d36f978ee0843e7cc87b56e63c3b7f281b4e46cbc58e9fe44316afa96294
 
 do_extract() {
 	mkdir -p ${DESTDIR}

--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.90.122
+version=1.90.124
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ maintainer="David Ivashevich <davidivashevich@gmail.com>"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=2fe00f79215c79a65968db4bca28ad6c0e52afc8b6194ff0de725404fba3623f
+checksum=6eb89a58149403e652c504df68fdf4e0c78067bc32557ee0872a65ded9b1eae3
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.12.3.1
+version=0.12.4.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=5673a1ce102e96f14d041ff4003d5df8afd3cdf14bf59c2d93fbdc9b9bd697e2
+checksum=3a04bc1e42c1b1e16b121345271330a756e0d20ccf75f63555ac92000a7bbead
 nostrip=yes
 noshlibs=yes
 


### PR DESCRIPTION
## Automated package updates — 2026-05-22

### Updated packages
- bitwarden-bin(2026.4.0)
- brave(1.90.124)
- helium-browser(0.12.4.1)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.