### PR TITLE
auto-update:  helium-browser(0.12.5.1) vscode-bin(1.122.0)

### DIFF
--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.12.4.1
+version=0.12.5.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=3a04bc1e42c1b1e16b121345271330a756e0d20ccf75f63555ac92000a7bbead
+checksum=b9465ab8dada957ea46ad9a73bd5432c4b3e77e1c88648e4795dfa0f0d9e5263
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.121.0
+version=1.122.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="Vostok Linux <packaging@vostoklinux.org>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=8cf24cc41441453e11e8fe1ae9e58d32970e23dced399835c4b0904263d66820
+checksum=d1a3d85695e24a7761abea7eda6877e93efca7bdcc46bde196435550fc69ceb2
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-05-28

### Updated packages
- helium-browser(0.12.5.1)
- vscode-bin(1.122.0)

### ⚠️ Failed updates
- noi-bin
- obsidian
- opencode
- runkit
- telegram-bin
- ttf-jetbrains-mono
- v2rayn-bin
- zapret2

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.