### PR TITLE
auto-update:  brave(1.90.128) opencode(1.15.12) vscode-bin(1.122.1)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.90.124
+version=1.90.128
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ maintainer="David Ivashevich <davidivashevich@gmail.com>"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=6eb89a58149403e652c504df68fdf4e0c78067bc32557ee0872a65ded9b1eae3
+checksum=3cf97f90b6ad0e2c3c227314438ce61f4021e3cc693d599153611ae445e42d14
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.15.11
+version=1.15.12
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=49317253722c698394980e1921ff28e919d79bb29d5c3f4cf314a4adaf7037cd
+checksum=ed6f8bce0fea1fb2be789bfe0cfbe7a4a819770e998e32836b0708c015303a67
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.122.0
+version=1.122.1
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=d1a3d85695e24a7761abea7eda6877e93efca7bdcc46bde196435550fc69ceb2
+checksum=b76e983771395da489ee0922f279b4ea1561e19bd70c453beccef8f59aea7c0a
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-05-29

### Updated packages
- brave(1.90.128)
- opencode(1.15.12)
- vscode-bin(1.122.1)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.