### PR TITLE
auto-update:  bitwarden-bin(2026.5.0) copyq(16.0.0) opencode(1.15.13)

### DIFF
--- a/srcpkgs/bitwarden-bin/template
+++ b/srcpkgs/bitwarden-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitwarden-bin'
 pkgname=bitwarden-bin
 _pkgname=bitwarden
-version=2026.4.0
+version=2026.5.0
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz"
@@ -11,7 +11,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://bitwarden.com"
 distfiles="https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-amd64.deb"
-checksum=bdd4d36f978ee0843e7cc87b56e63c3b7f281b4e46cbc58e9fe44316afa96294
+checksum=2ea59874bac7f67f5663828d028449168050d4538b5e6adea69e13b199249226
 noverifyrdeps=yes
 nostrip=yes
 noshlibs=yes

--- a/srcpkgs/copyq/template
+++ b/srcpkgs/copyq/template
@@ -1,6 +1,6 @@
 # Template file for 'copyq'
 pkgname=copyq
-version=15.0.0
+version=16.0.0
 revision=1
 build_style=cmake
 configure_args="
@@ -30,4 +30,4 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/hluk/CopyQ"
 distfiles="https://github.com/hluk/CopyQ/archive/refs/tags/v${version}.tar.gz"
-checksum="19665e503997e9d2ffd6f062df43255ee2be38d888d8cc22215474196016bb39"
+checksum=3d876f74cf32913e37b1cdeaca0c61cce857174f064bb128f76fd0fa3abdb326

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.15.12
+version=1.15.13
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=ed6f8bce0fea1fb2be789bfe0cfbe7a4a819770e998e32836b0708c015303a67
+checksum=51785a07c009f27c5125a5235c5a0ff78433dace07f73fbc44eb672ead4b3d79
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-05-31

### Updated packages
- bitwarden-bin(2026.5.0)
- copyq(16.0.0)
- opencode(1.15.13)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.