### PR TITLE
auto-update:  brave(1.91.168) opencode(1.16.0)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.90.128
+version=1.91.168
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ maintainer="David Ivashevich <davidivashevich@gmail.com>"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=3cf97f90b6ad0e2c3c227314438ce61f4021e3cc693d599153611ae445e42d14
+checksum=b662545261da9c58a0f0fabbab43deb60b16119bd86c06fec636b4a808a61f27
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.15.13
+version=1.16.0
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=51785a07c009f27c5125a5235c5a0ff78433dace07f73fbc44eb672ead4b3d79
+checksum=a741c43e737b2033f5e7ee151b162341e441034d6a64b172272a3f3a3729e87d
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-06-05

### Updated packages
- brave(1.91.168)
- opencode(1.16.0)

### ⚠️ Failed updates
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.