### PR TITLE
auto-update:  helium-browser(0.13.1.1) zapret2(1.0)

### DIFF
--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.12.5.1
+version=0.13.1.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=b9465ab8dada957ea46ad9a73bd5432c4b3e77e1c88648e4795dfa0f0d9e5263
+checksum=64053e2074ae2aef0a8aab602be7def75e02ff2eca4e8556cc2f9daea764f993
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/zapret2/template
+++ b/srcpkgs/zapret2/template
@@ -1,6 +1,6 @@
 # Template file for 'zapret2'
 pkgname=zapret2
-version=0.9.5.2
+version=1.0
 revision=1
 build_style=gnu-makefile
 makedepends="LuaJIT-devel libcap-devel zlib-devel libnetfilter_queue-devel"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/bol-van/zapret2"
 distfiles="https://github.com/bol-van/zapret2/archive/refs/tags/v${version}.tar.gz"
-checksum="6ef1834a34171ee76791594498b4cc01507da3efcbe941c4906aeb679b4c4e8d"
+checksum=f6350fc7b4f703e950851ed168dd4115355465e934ad0880b7e1e8af401e1eac
 
 do_prepare() {
     cd ipset


### PR DESCRIPTION
## Automated package updates — 2026-06-07

### Updated packages
- helium-browser(0.13.1.1)
- zapret2(1.0)

### ⚠️ Failed updates
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.