### PR TITLE
auto-update:  zapret2(1.0.1)

### DIFF
--- a/srcpkgs/zapret2/template
+++ b/srcpkgs/zapret2/template
@@ -1,6 +1,6 @@
 # Template file for 'zapret2'
 pkgname=zapret2
-version=1.0
+version=1.0.1
 revision=1
 build_style=gnu-makefile
 makedepends="LuaJIT-devel libcap-devel zlib-devel libnetfilter_queue-devel"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/bol-van/zapret2"
 distfiles="https://github.com/bol-van/zapret2/archive/refs/tags/v${version}.tar.gz"
-checksum=f6350fc7b4f703e950851ed168dd4115355465e934ad0880b7e1e8af401e1eac
+checksum=bb4537853326060378e90c11c6448746877ba561348657e7b64ce2952f955972
 
 do_prepare() {
     cd ipset


### PR DESCRIPTION
## Automated package updates — 2026-06-08

### Updated packages
- zapret2(1.0.1)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.