### PR TITLE
auto-update:  brave(1.91.171) chatbox(1.21.0) helium-browser(0.13.2.1) opencode(1.17.0) telegram-bin(6.9.1) vscode-bin(1.123.2)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.91.168
+version=1.91.171
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ maintainer="David Ivashevich <davidivashevich@gmail.com>"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=b662545261da9c58a0f0fabbab43deb60b16119bd86c06fec636b4a808a61f27
+checksum=8c2d57363c05326295fdfe87162af850be2d7cc5863ffd59bb48f7f12c53eebd
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/chatbox/template
+++ b/srcpkgs/chatbox/template
@@ -1,6 +1,6 @@
 # Template file for 'chatbox'
 pkgname=chatbox
-version=1.20.3
+version=1.21.0
 revision=1
 archs="x86_64"
 wrksrc="chatbox-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/chatboxai/chatbox"
 distfiles="https://github.com/chatboxai/chatbox/releases/download/v${version}/Chatbox-${version}-amd64.deb"
-checksum=7a5b86200c180142ee7d4ed5d56edaabba3a3b37b3b8d8c4eed32678d327e141
+checksum=0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.13.1.1
+version=0.13.2.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=64053e2074ae2aef0a8aab602be7def75e02ff2eca4e8556cc2f9daea764f993
+checksum=23d56a5c4db414d8c4cfd172bdc099f19a9165b3c853e42d18f6e501dc09464f
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.16.2
+version=1.17.0
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=06a79c5bb7f8d01716b2440712cf67facd36db59188809aeb232374b206bd429
+checksum=5c82f608207ae8254c43e331d90d96915aea19e78474e311b2c88b6bbb7c93f0
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=6.8.2
+version=6.9.1
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=3e31fdabc2be8bc62e486da0586932e8115087e22dece8098977d14f1d13cf2b
+checksum=883c39c81807bbef7d336dfc3f3b48b1e58f506642228044e09f1aa76d7a2b75
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.123.0
+version=1.123.2
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="Vostok Linux <packaging@vostoklinux.org>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=2fdef947717befd2e06854cbe01e99b4898f7752f25e12269c38023e63b93c8f
+checksum=a0d5e0345a411a8b2bd94c56929c3de965947a5fdeb30d3396eab7b2d7a6c60f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-10

### Updated packages
- brave(1.91.171)
- chatbox(1.21.0)
- helium-browser(0.13.2.1)
- opencode(1.17.0)
- telegram-bin(6.9.1)
- vscode-bin(1.123.2)

### ⚠️ Failed updates
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.