### PR TITLE
auto-update:  amneziavpn(4.8.18.0) opencode(1.17.3) zen-browser(1.21)

### DIFF
--- a/srcpkgs/amneziavpn/template
+++ b/srcpkgs/amneziavpn/template
@@ -1,6 +1,6 @@
 # Template file for 'amneziavpn'
 pkgname=amneziavpn
-version=4.8.15.4
+version=4.8.18.0
 revision=1
 archs="x86_64"
 wrksrc="${pkgname}-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/amnezia-vpn/amnezia-client"
 distfiles="https://github.com/amnezia-vpn/amnezia-client/releases/download/${version}/AmneziaVPN_${version}_linux_x64.tar"
-checksum=64f385da8d014a45e96c770f6e0f9a0fc3124e35e557d5b2ec22725264f92b90
+checksum=2f6ecb39407d95b3d68d12c8d54345e0aee0de0ea7719f6d09f3f4c691c75437
 nopie=yes
 noverifyrdeps=yes
 disable_shlib_provides=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.0
+version=1.17.3
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=5c82f608207ae8254c43e331d90d96915aea19e78474e311b2c88b6bbb7c93f0
+checksum=d4bd238a2c1ff56aca1cd3397d21a0a317f5992234517a7f8e2afbbd72010a7d
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.20.2
+version=1.21
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=36ad444c06c22b0ea1d3d1d15013f32bc9ce6ea907070ab277f700fde0bc1674
+checksum=a1473c843465a0683f5f300edfd5c358c6e2d0588392b0e16c6f826ad9d678b9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-11

### Updated packages
- amneziavpn(4.8.18.0)
- opencode(1.17.3)
- zen-browser(1.21)

### ⚠️ Failed updates
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.