### PR TITLE
auto-update:  brave(1.91.172) chatbox(1.21.1) helium-browser(0.13.3.1) opencode(1.17.4) telegram-bin(6.9.2) vscode-bin(1.124.2)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.91.171
+version=1.91.172
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=8c2d57363c05326295fdfe87162af850be2d7cc5863ffd59bb48f7f12c53eebd
+checksum=e90f1838e1d0e7bab775e3b07d6d13d01db743b15847436b725ec09616285a93
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/chatbox/template
+++ b/srcpkgs/chatbox/template
@@ -1,6 +1,6 @@
 # Template file for 'chatbox'
 pkgname=chatbox
-version=1.21.0
+version=1.21.1
 revision=1
 archs="x86_64"
 wrksrc="chatbox-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://chatboxai.app/"
 distfiles="https://download.chatboxai.app/releases/Chatbox-${version}-x86_64.AppImage"
-checksum=a7173b8e62debf5a30d12dd4144a9d523f8c5607a4307f362669ebc0b18669e5
+checksum=02d81637382731fa6adea0d2ba3e76be1f366125fa6468e19baded83d69184c3
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.13.2.1
+version=0.13.3.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=23d56a5c4db414d8c4cfd172bdc099f19a9165b3c853e42d18f6e501dc09464f
+checksum=452f929f8d95f878c2c38d4dd736b231522a9601fe8b607621d549c013e6c34d
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.3
+version=1.17.4
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=d4bd238a2c1ff56aca1cd3397d21a0a317f5992234517a7f8e2afbbd72010a7d
+checksum=a2ece9181aab3817a6b59fa390b6d459b187e3ec917be802ecbca88b632c5ef9
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=6.9.1
+version=6.9.2
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=883c39c81807bbef7d336dfc3f3b48b1e58f506642228044e09f1aa76d7a2b75
+checksum=e061c8c89c14d164dc621b33bcce052fc7c93cbceb0c77362b62aa5a92b31ac1
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.124.0
+version=1.124.2
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=79488ea5224271d0de4a4dcd46fe1fc4ddd14ab1b86b1181e94e738790c46577
+checksum=2f4a3dfafc5f0249ad38726f99fd06f1621ba776d78c0bae200b53b45bdbc234
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-12

### Updated packages
- brave(1.91.172)
- chatbox(1.21.1)
- helium-browser(0.13.3.1)
- opencode(1.17.4)
- telegram-bin(6.9.2)
- vscode-bin(1.124.2)

### ⚠️ Failed updates
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.