### PR TITLE
auto-update:  opencode(1.17.6)

### DIFF
--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.4
+version=1.17.6
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=a2ece9181aab3817a6b59fa390b6d459b187e3ec917be802ecbca88b632c5ef9
+checksum=6cac705f9259415365079961c5f652269ed9e3a4613ce874f15a9d36366bea7d
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-06-14

### Updated packages
- opencode(1.17.6)

### ⚠️ Failed updates
- telegram-bin
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- zapret2
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.