### PR TITLE
auto-update:  amneziavpn(4.8.19.0) firefox-nightly(154.0a1)

### DIFF
--- a/srcpkgs/amneziavpn/template
+++ b/srcpkgs/amneziavpn/template
@@ -1,6 +1,6 @@
 # Template file for 'amneziavpn'
 pkgname=amneziavpn
-version=4.8.18.0
+version=4.8.19.0
 revision=1
 archs="x86_64"
 wrksrc="${pkgname}-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/amnezia-vpn/amnezia-client"
 distfiles="https://github.com/amnezia-vpn/amnezia-client/releases/download/${version}/AmneziaVPN_${version}_linux_x64.tar"
-checksum=2f6ecb39407d95b3d68d12c8d54345e0aee0de0ea7719f6d09f3f4c691c75437
+checksum=0b3da257ec93b7f1acc9f90913a6354bf583590e01a33791cd7cf7bb3be1c3b8
 nopie=yes
 noverifyrdeps=yes
 disable_shlib_provides=yes

--- a/srcpkgs/firefox-nightly/template
+++ b/srcpkgs/firefox-nightly/template
@@ -1,6 +1,6 @@
 # Template file for 'firefox-nightly'
 pkgname=firefox-nightly
-version=153.0a1
+version=154.0a1
 revision=1
 archs="x86_64"
 wrksrc="firefox"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/firefox/channel/desktop/#nightly"
 distfiles="https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US"
-checksum=5cf7dfb73f7f6aa129552bbfabae1a581887808ceb67a96ff9300342ca06a326
+checksum=5e8ab067434475337f5d69b8bee9e573676b13cb286d070dddf67fe449c4e9fb
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-16

### Updated packages
- amneziavpn(4.8.19.0)
- firefox-nightly(154.0a1)

### ⚠️ Failed updates
- runkit
- rustdesk
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.