### PR TITLE
auto-update:  google-chrome(149.0.7827.155) librewolf(152.0.1) slack-desktop(4.50.140) zapret2(1.0.2)

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=149.0.7827.114
+version=149.0.7827.155
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -8,8 +8,8 @@ short_desc="The popular web browser by Google (Stable Channel)"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
-distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=195bde858f9ee6d84cde71d831077fb88f074e78ef2ffc3c51e469516a2ece50
+distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-149.0.7827.155_amd64.deb"
+checksum=ab9dbab873fff677deb2cfd95ea60b9295ebd53b58ec8533e9e1110b2451e540
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=151.0.4.1
+version=152.0.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -9,8 +9,8 @@ short_desc="Community-maintained fork of Firefox, focused on privacy, security a
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://librewolf.net/"
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/151.0.4-1/librewolf-151.0.4-1-linux-x86_64-package.tar.xz"
-checksum=fd301af689535ba6a8d9b3b91745077f8e60b0b37d320b2aa3f6d390e8f899e8
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0-1/librewolf-152.0-1-linux-x86_64-package.tar.xz"
+checksum=b08a720a97e8f62819d0f31dd58eec748a2e8bcf1d0bd0e39708cde4ce472ec4
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.50.136
+version=4.50.140
 revision=1
 archs="x86_64"
 wrksrc="slack-desktop-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Slack"
 homepage="https://slack.com/downloads"
 distfiles="https://downloads.slack-edge.com/desktop-releases/linux/x64/${version}/slack-desktop-${version}-amd64.deb"
-checksum=60ba516209527b66835874eff46d76953245f35f3a6416ea162e3f5b13ae7c74
+checksum=61a83274b91f76dbd4ffbc07d58585c326af3f838c45f9b7f3dc1a4be99f9156
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zapret2/template
+++ b/srcpkgs/zapret2/template
@@ -1,6 +1,6 @@
 # Template file for 'zapret2'
 pkgname=zapret2
-version=1.0.1
+version=1.0.2
 revision=1
 build_style=gnu-makefile
 makedepends="LuaJIT-devel libcap-devel zlib-devel libnetfilter_queue-devel"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/bol-van/zapret2"
 distfiles="https://github.com/bol-van/zapret2/archive/refs/tags/v${version}.tar.gz"
-checksum=bb4537853326060378e90c11c6448746877ba561348657e7b64ce2952f955972
+checksum=b778c9fda24de6d534881ce6c9ff5817ea245163d3b96dc1c1fd491704252e60
 
 do_prepare() {
     cd ipset


### PR DESCRIPTION
## Automated package updates — 2026-06-17

### Updated packages
- google-chrome(149.0.7827.155)
- librewolf(152.0.1)
- slack-desktop(4.50.140)
- zapret2(1.0.2)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.