### PR TITLE
auto-update:  brave(1.91.175) google-chrome(149.0.7827.155) librewolf(152.0.1) opencode(1.17.8) slack-desktop(4.50.140) vscode-bin(1.125.0) zapret2(1.0.2) zed(1.7.2) zen-browser(1.21.2)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.91.172
+version=1.91.175
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=e90f1838e1d0e7bab775e3b07d6d13d01db743b15847436b725ec09616285a93
+checksum=7400db6ed7a31962bca1d6b65ef6dc164db1f3f85795da4d55c0e8563025da56
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=149.0.7827.114
+version=149.0.7827.155
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -8,8 +8,8 @@ short_desc="The popular web browser by Google (Stable Channel)"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
-distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=195bde858f9ee6d84cde71d831077fb88f074e78ef2ffc3c51e469516a2ece50
+distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-149.0.7827.155_amd64.deb"
+checksum=ab9dbab873fff677deb2cfd95ea60b9295ebd53b58ec8533e9e1110b2451e540
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=151.0.4.1
+version=152.0.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -9,8 +9,8 @@ short_desc="Community-maintained fork of Firefox, focused on privacy, security a
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://librewolf.net/"
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/151.0.4-1/librewolf-151.0.4-1-linux-x86_64-package.tar.xz"
-checksum=fd301af689535ba6a8d9b3b91745077f8e60b0b37d320b2aa3f6d390e8f899e8
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0-1/librewolf-152.0-1-linux-x86_64-package.tar.xz"
+checksum=b08a720a97e8f62819d0f31dd58eec748a2e8bcf1d0bd0e39708cde4ce472ec4
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.7
+version=1.17.8
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=60fe5a92dc9af64ec079348fedde17e12da6a867efe7e8353be8038480607924
+checksum=13fffc29227093462b7d14777ea6b804cfd94c2612819c101bbf933d862b1e5f
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.50.136
+version=4.50.140
 revision=1
 archs="x86_64"
 wrksrc="slack-desktop-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Slack"
 homepage="https://slack.com/downloads"
 distfiles="https://downloads.slack-edge.com/desktop-releases/linux/x64/${version}/slack-desktop-${version}-amd64.deb"
-checksum=60ba516209527b66835874eff46d76953245f35f3a6416ea162e3f5b13ae7c74
+checksum=61a83274b91f76dbd4ffbc07d58585c326af3f838c45f9b7f3dc1a4be99f9156
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.124.2
+version=1.125.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=2f4a3dfafc5f0249ad38726f99fd06f1621ba776d78c0bae200b53b45bdbc234
+checksum=4d3ba51e90a24f679acb6b5beded6e6f5eb8ae0b6d067077e82738255a317f4f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zapret2/template
+++ b/srcpkgs/zapret2/template
@@ -1,6 +1,6 @@
 # Template file for 'zapret2'
 pkgname=zapret2
-version=1.0.1
+version=1.0.2
 revision=1
 build_style=gnu-makefile
 makedepends="LuaJIT-devel libcap-devel zlib-devel libnetfilter_queue-devel"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/bol-van/zapret2"
 distfiles="https://github.com/bol-van/zapret2/archive/refs/tags/v${version}.tar.gz"
-checksum=bb4537853326060378e90c11c6448746877ba561348657e7b64ce2952f955972
+checksum=b778c9fda24de6d534881ce6c9ff5817ea245163d3b96dc1c1fd491704252e60
 
 do_prepare() {
     cd ipset

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.6.3
+version=1.7.2
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=0fd618752e4282fa46977863af6b7cdc190ae2db7e0b33aeaf835438e0538db5
+checksum=b9d6987934c2a03833f5f196508f15ab8868d42396dc1a7607186ad70d6e9c02
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.1
+version=1.21.2
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=a7facf3f12fe604f0bc5af3d93d8a5ef7325a3c6007fdcfc2aae6aa5e8100ed9
+checksum=b3a2e027c2c99101a720679b72e51f04ea4c05d65541990f132be799d6acb237
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-18

### Updated packages
- brave(1.91.175)
- google-chrome(149.0.7827.155)
- librewolf(152.0.1)
- opencode(1.17.8)
- slack-desktop(4.50.140)
- vscode-bin(1.125.0)
- zapret2(1.0.2)
- zed(1.7.2)
- zen-browser(1.21.2)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.