### PR TITLE
auto-update:  google-chrome(149.0.7827.155) google-chrome-dev(151.0.7896.2) helium-browser(0.13.4.1) librewolf(152.0.1.2) logitune(0.3.6) vscode-bin(1.124.2) zen-browser(1.21.3)

### DIFF
--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=151.0.7886.2
+version=151.0.7896.2
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=61f6e6d456fdcca324b4f638f4b3708a0e1a483a691dbea47a71275ab2a7655a
+checksum=ec9fdd8762f1d83838c492aa16c1f39c2d384ccc0cd9d03e673c13cc86e0a6f9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=149.0.7827.102
+version=149.0.7827.155
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -8,8 +8,8 @@ short_desc="The popular web browser by Google (Stable Channel)"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
-distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=113a7b114468374a78e5c367c1ca7afdaa0fc8a1d27fe58fc94bca87e47b6e9e
+distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-149.0.7827.155_amd64.deb"
+checksum=ab9dbab873fff677deb2cfd95ea60b9295ebd53b58ec8533e9e1110b2451e540
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.13.3.1
+version=0.13.4.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=452f929f8d95f878c2c38d4dd736b231522a9601fe8b607621d549c013e6c34d
+checksum=cf6deea7e4fa6e3e85f9c42c96623dd9b124b08030d4e407448ae641269ac58f
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=152.0.1
+version=152.0.1.2
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/${_upver}/librewolf-${_upver}-linux-x86_64-package.tar.xz"
-checksum=b08a720a97e8f62819d0f31dd58eec748a2e8bcf1d0bd0e39708cde4ce472ec4
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.1-2/librewolf-152.0.1-2-linux-x86_64-package.tar.xz"
+checksum=37eeac189080a2f44bcf94f614b872b1ca4d19c8dbf1ec6fcf9d234a5817472f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/logitune/template
+++ b/srcpkgs/logitune/template
@@ -1,6 +1,6 @@
 # Template file for 'logitune'
 pkgname=logitune
-version=0.3.5
+version=0.3.6
 revision=1
 build_style=cmake
 configure_args="
@@ -15,7 +15,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/mmaher88/logitune"
 distfiles="https://github.com/mmaher88/logitune/archive/v${version}.tar.gz"
-checksum=f5304a1e36df2d422f2aeb52f70816d7cc2f7786258c9fffce0686f902fd9dd9
+checksum=b2bf875703ffcca1ebdcd71ac68a6a8c7dd7f39227bfcdba628f3dcf4dc692a8
 noverifyrdeps=yes
 noshlibprovides=yes
 

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.125.0
+version=1.124.2
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=4d3ba51e90a24f679acb6b5beded6e6f5eb8ae0b6d067077e82738255a317f4f
+checksum=2f4a3dfafc5f0249ad38726f99fd06f1621ba776d78c0bae200b53b45bdbc234
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.2
+version=1.21.3
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=b3a2e027c2c99101a720679b72e51f04ea4c05d65541990f132be799d6acb237
+checksum=a0ceeaf931c15d7c37de4faef4ea247eeb10e4b85a9e44b6304277bf3884ae4f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-19

### Updated packages
- google-chrome(149.0.7827.155)
- google-chrome-dev(151.0.7896.2)
- helium-browser(0.13.4.1)
- librewolf(152.0.1.2)
- logitune(0.3.6)
- vscode-bin(1.124.2)
- zen-browser(1.21.3)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.