### PR TITLE
auto-update:  opencode(1.17.9) vscode-bin(1.125.1)

### DIFF
--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.8
+version=1.17.9
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=13fffc29227093462b7d14777ea6b804cfd94c2612819c101bbf933d862b1e5f
+checksum=85aeac95258d409d16ca34f1cfcd74c78d9d1a70b0a4154128b588e1405384f9
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.124.2
+version=1.125.1
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=2f4a3dfafc5f0249ad38726f99fd06f1621ba776d78c0bae200b53b45bdbc234
+checksum=119dd60ef898ea1409fb0160ab9508ea09f8ae6c41d3058b936aeb007e2ab223
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-21

### Updated packages
- opencode(1.17.9)
- vscode-bin(1.125.1)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.