### PR TITLE
auto-update:  brave(1.91.178) google-chrome(149.0.7827.196) helium-browser(0.13.5.1) insomnia(13.0.2) librewolf(152.0.2.1) opencode(1.17.10) portainer(2.39.4) slack-desktop(4.50.143) ventoy(1.1.15) vscode-bin(1.126.0) zed(1.8.2)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.91.175
+version=1.91.178
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=7400db6ed7a31962bca1d6b65ef6dc164db1f3f85795da4d55c0e8563025da56
+checksum=2971ad30e9a56f619810983152cba809d0f0d8d721dc0683af49dfc29d81cea2
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=149.0.7827.155
+version=149.0.7827.196
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=8343c77f2088a4e4366f0dfe4e68aefa3b7e79326cd2ca3bd7eb63c611f06556
+checksum=0785c8b8beeafe419177fc36bcf99f92fb2f16dbc77af84be487c2e6ed7822e6
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.13.4.1
+version=0.13.5.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=cf6deea7e4fa6e3e85f9c42c96623dd9b124b08030d4e407448ae641269ac58f
+checksum=5409dc2fbf27c974513543d9d9cd10b9dc45adfc72eed5c4d8d14de2d79e7b39
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/insomnia/template
+++ b/srcpkgs/insomnia/template
@@ -1,6 +1,6 @@
 # Template file for 'insomnia'
 pkgname=insomnia
-version=13.0.1
+version=13.0.2
 revision=1
 archs="x86_64"
 wrksrc="insomnia-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://insomnia.rest/"
 distfiles="https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.deb"
-checksum=9766c66f0041b0c3bb5943c18acd52ac5c0c1466478e6895a2a497eb57adcad7
+checksum=c0805c435f115c0820c4c0349384a4483752b46a9b4648e3068dc993c063a570
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=152.0.1.2
+version=152.0.2.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.1-2/librewolf-152.0.1-2-linux-x86_64-package.tar.xz"
-checksum=37eeac189080a2f44bcf94f614b872b1ca4d19c8dbf1ec6fcf9d234a5817472f
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.2-1/librewolf-152.0.2-1-linux-x86_64-package.tar.xz"
+checksum=4ead9b8fbe68657487d981d74a18d146ce00ab1a3ce81bb038d5eef88b1d0ae0
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.9
+version=1.17.10
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=85aeac95258d409d16ca34f1cfcd74c78d9d1a70b0a4154128b588e1405384f9
+checksum=ac24ff27647b57c44e4b0d00ffe4d9e9db32f148b6886b39a83555604fb382cd
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/portainer/template
+++ b/srcpkgs/portainer/template
@@ -1,6 +1,6 @@
 # Template file for 'portainer'
 pkgname=portainer
-version=2.39.3
+version=2.39.4
 revision=1
 archs="x86_64"
 wrksrc="portainer-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Zlib"
 homepage="https://www.portainer.io/"
 distfiles="https://github.com/portainer/portainer/releases/download/${version}/portainer-${version}-linux-amd64.tar.gz"
-checksum=6f5eaeb5968e355fcf40409d89085d569ac48ae099cca80ac6338c8aadae287e
+checksum=4082de908603a25f642c9d54c7c6da03250bb05c5bd45d26f36d5225a82e35e5
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.50.140
+version=4.50.143
 revision=1
 archs="x86_64"
 wrksrc="slack-desktop-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Slack"
 homepage="https://slack.com/downloads"
 distfiles="https://downloads.slack-edge.com/desktop-releases/linux/x64/${version}/slack-desktop-${version}-amd64.deb"
-checksum=61a83274b91f76dbd4ffbc07d58585c326af3f838c45f9b7f3dc1a4be99f9156
+checksum=93ca12a293d4993ed52d280a3928bfa542d270befcdce3624366a019fbb59630
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ventoy/template
+++ b/srcpkgs/ventoy/template
@@ -1,6 +1,6 @@
 # Template file for 'ventoy'
 pkgname=ventoy
-version=1.1.12
+version=1.1.15
 revision=1
 archs="x86_64"
 wrksrc="ventoy-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.ventoy.net"
 distfiles="https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz"
-checksum=04620b546bcc5eeeb5971767595b3713ee3de71580a82449053c53a7cb32fcd9
+checksum=dfed601b689fa4f552bc4c44dc0a45ef893226630fb11f43ca3ab618ff429279
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.125.1
+version=1.126.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=119dd60ef898ea1409fb0160ab9508ea09f8ae6c41d3058b936aeb007e2ab223
+checksum=7e3d8cc530728851e5dabe6b5cdfc9d66a86ebdb91348bc3643ba3046e5c231c
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.7.2
+version=1.8.2
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=b9d6987934c2a03833f5f196508f15ab8868d42396dc1a7607186ad70d6e9c02
+checksum=5096390f6d1a209bc2acb8d9b634dcd516709af33a0fc2ff62a0edb0cbc88108
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-25

### Updated packages
- brave(1.91.178)
- google-chrome(149.0.7827.196)
- helium-browser(0.13.5.1)
- insomnia(13.0.2)
- librewolf(152.0.2.1)
- opencode(1.17.10)
- portainer(2.39.4)
- slack-desktop(4.50.143)
- ventoy(1.1.15)
- vscode-bin(1.126.0)
- zed(1.8.2)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.