### PR TITLE
auto-update:  bitwarden-bin(2026.6.0) google-chrome(149.0.7827.200) opencode(1.17.11) ventoy(1.1.16)

### DIFF
--- a/srcpkgs/bitwarden-bin/template
+++ b/srcpkgs/bitwarden-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitwarden-bin'
 pkgname=bitwarden-bin
 _pkgname=bitwarden
-version=2026.5.0
+version=2026.6.0
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz"
@@ -11,7 +11,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://bitwarden.com"
 distfiles="https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-amd64.deb"
-checksum=2ea59874bac7f67f5663828d028449168050d4538b5e6adea69e13b199249226
+checksum=e2a9e0d476624d2fed188ed2dff993d448b992895c7a7d838ff9a0145f64581f
 noverifyrdeps=yes
 nostrip=yes
 noshlibs=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=149.0.7827.196
+version=149.0.7827.200
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=0785c8b8beeafe419177fc36bcf99f92fb2f16dbc77af84be487c2e6ed7822e6
+checksum=1c308fae11f8e27293afa1739bd4aa015fd5766b72c75ce72195ec3e41a612a8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.10
+version=1.17.11
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=ac24ff27647b57c44e4b0d00ffe4d9e9db32f148b6886b39a83555604fb382cd
+checksum=6aefcbbb7f04cdb4642be5208ddbfabb3c3d274f816bf42bff72eea5c244dca2
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/ventoy/template
+++ b/srcpkgs/ventoy/template
@@ -1,6 +1,6 @@
 # Template file for 'ventoy'
 pkgname=ventoy
-version=1.1.15
+version=1.1.16
 revision=1
 archs="x86_64"
 wrksrc="ventoy-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.ventoy.net"
 distfiles="https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz"
-checksum=dfed601b689fa4f552bc4c44dc0a45ef893226630fb11f43ca3ab618ff429279
+checksum=a9ffd7bd5e26df486cafff924b8dbcb6caae20cbe2b179a009fe59ae740c7572
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-06-26

### Updated packages
- bitwarden-bin(2026.6.0)
- google-chrome(149.0.7827.200)
- opencode(1.17.11)
- ventoy(1.1.16)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.