### PR TITLE
auto-update:  brave(1.92.134) bruno(3.5.1) helium-browser(0.14.2.1)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.91.180
+version=1.92.134
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=6d5349a7c02043720b9bd655eddea85691813a309bc474485211dd66730d5e5f
+checksum=fdda298329b9058c9d4e4ae0841d0e50101cbf8c2fe22deaccd44223b7b535cd
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/bruno/template
+++ b/srcpkgs/bruno/template
@@ -1,6 +1,6 @@
 # Template file for 'bruno'
 pkgname=bruno
-version=3.5.0
+version=3.5.1
 revision=1
 archs="x86_64"
 wrksrc="bruno-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://www.usebruno.com/"
 distfiles="https://github.com/usebruno/bruno/releases/download/v${version}/bruno_${version}_amd64_linux.deb"
-checksum=53a39691e4525dca8f84e0e5a6dc0e890835f36e3b8a2cadf792583aa3c82e65
+checksum=07e16f710ddb687d246522935a449360df2f03f32b1a739afff0a3d483e9f80f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.13.6.1
+version=0.14.2.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=65c668fef1575ab663b8f8c8b763186ecc6ce0b53b36fa41dc8ea6acfcc02631
+checksum=2504392be594677972e6692534f1995834e5abe989aaa4b4da82600b78a7e54d
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"


### PR DESCRIPTION
## Automated package updates — 2026-07-03

### Updated packages
- brave(1.92.134)
- bruno(3.5.1)
- helium-browser(0.14.2.1)

### ⚠️ Failed updates
- ventoy
- vfox
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.