### PR TITLE
auto-update:  helium-browser(0.14.3.1) zen-browser(1.21.5)

### DIFF
--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.2.1
+version=0.14.3.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=2504392be594677972e6692534f1995834e5abe989aaa4b4da82600b78a7e54d
+checksum=ba64435dc1e50d10d6a5d3f8c31afcd6af9c517923888c7283601c25115068c0
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.4
+version=1.21.5
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=02b814ccd0e6659468d438fa3be91c0e9934b1f0d5c58078319ea7a6e26729eb
+checksum=0dea09bbc5fed9e1e32839f288a609b0b20eb1befed8d4f892e222a65dfaa069
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-05

### Updated packages
- helium-browser(0.14.3.1)
- zen-browser(1.21.5)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.