### PR TITLE
auto-update:  google-chrome-dev(152.0.7928.2) helium-browser(0.14.3.1) opencode(1.17.14) rustdesk(1.4.9) zen-browser(1.21.5)

### DIFF
--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=151.0.7912.0
+version=152.0.7928.2
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=1a32beccfc2e56ac00090d852f02112f4be575294c149ec7f2e2866beb992d5d
+checksum=6cd9b8defa6fdccdc87d9fdb239f6504001e6f7ca281355172805790eb06c9cf
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.2.1
+version=0.14.3.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=2504392be594677972e6692534f1995834e5abe989aaa4b4da82600b78a7e54d
+checksum=ba64435dc1e50d10d6a5d3f8c31afcd6af9c517923888c7283601c25115068c0
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.13
+version=1.17.14
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=157afa289d1a8d9372de0ce19ac726119b937a1f6b201808d46f06e4e59bb348
+checksum=38a870d0951a73f640eae7db1729364bc4e3a8405f7f3e1ded4994f7cd53ed2e
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/rustdesk/template
+++ b/srcpkgs/rustdesk/template
@@ -1,6 +1,6 @@
 # Template file for 'rustdesk'
 pkgname=rustdesk
-version=1.4.8
+version=1.4.9
 revision=1
 archs="x86_64"
 wrksrc="rustdesk-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="AGPL-3.0-or-later"
 homepage="https://rustdesk.com/"
 distfiles="https://github.com/rustdesk/rustdesk/releases/download/${version}/rustdesk-${version}-x86_64.deb"
-checksum=c426f0a50ce141be3babf653ee920f43c30cf5159deb7d46b0a58ee07d5f547e
+checksum=7244ba47c40e804172044bfbe659467c54ce46554c98e78c8c0406f1d612fda3
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.4
+version=1.21.5
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=02b814ccd0e6659468d438fa3be91c0e9934b1f0d5c58078319ea7a6e26729eb
+checksum=0dea09bbc5fed9e1e32839f288a609b0b20eb1befed8d4f892e222a65dfaa069
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-07

### Updated packages
- google-chrome-dev(152.0.7928.2)
- helium-browser(0.14.3.1)
- opencode(1.17.14)
- rustdesk(1.4.9)
- zen-browser(1.21.5)



This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.