### PR TITLE
auto-update:  google-chrome(150.0.7871.100) librewolf(152.0.5.1) musescore-bin(4.7.4.260706075) opencode(1.17.15) simplex-desktop(6.5.6) vscode-bin(1.128.0)

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=150.0.7871.46
+version=150.0.7871.100
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=69b40139fb73a021a749f32fcde0853fb1781b6f3a8b3caf173ad8f6747faa7c
+checksum=49b57f002ce6df5080d5f82542dc5cf11741b9379a97f1d75d7b5415ad086079
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=152.0.4.1
+version=152.0.5.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.4-1/librewolf-152.0.4-1-linux-x86_64-package.tar.xz"
-checksum=e2f9acbfddc436db5e135f2e18917664485a440de718983ffd66187414442228
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.5-1/librewolf-152.0.5-1-linux-x86_64-package.tar.xz"
+checksum=f58d27dd41d12bd5a02a128520c07708b9a1d46a79687a0888ac6528d29ee607
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/musescore-bin/template
+++ b/srcpkgs/musescore-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'musescore-bin'
 pkgname=musescore-bin
-version=4.7.3.260608135
+version=4.7.4.260706075
 revision=1
 archs="x86_64"
 wrksrc="musescore-${version}"
@@ -9,8 +9,8 @@ short_desc="Music notation and composition software (AppImage repack)"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://musescore.org/"
-distfiles="https://github.com/musescore/MuseScore/releases/download/v4.7.3/MuseScore-Studio-${version}-x86_64.AppImage"
-checksum=81248da5cee796a99c74cbadf29005433cd851798b95a362d19864003dc7b292
+distfiles="https://github.com/musescore/MuseScore/releases/download/v4.7.4/MuseScore-Studio-4.7.4.260706075-x86_64.AppImage"
+checksum=9233ed1b87d3e6b45722278f3c286dcd41e83da778bd0f80a1dd04949696ad93
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.14
+version=1.17.15
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=38a870d0951a73f640eae7db1729364bc4e3a8405f7f3e1ded4994f7cd53ed2e
+checksum=0e1353771192c7d2dc0c610d61ff70668bb8a4420dc4d9e35cfd33d7245f3e67
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/simplex-desktop/template
+++ b/srcpkgs/simplex-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'simplex-desktop'
 pkgname=simplex-desktop
-version=6.5.5
+version=6.5.6
 revision=1
 archs="x86_64"
 wrksrc="simplex-desktop-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="AGPL-3.0-or-later"
 homepage="https://simplex.chat/"
 distfiles="https://github.com/simplex-chat/simplex-chat/releases/download/v${version}/simplex-desktop-ubuntu-22_04-x86_64.deb"
-checksum=b93d7d396bcf8f1a86658d2041e8a76d529181fafc33dad930da409493417f24
+checksum=144c10bb4c88d03a902456f890e7bb194b2ab46ce127f17a6c939ad138051729
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.127.0
+version=1.128.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=e06fb36791c9baf7495d4b7dc0f5aaa8254e7d1a60a5ee43e6c7debc05c962b5
+checksum=a9b4ce974ecc10c7456da9879763bf0a7a432710bd26c95a89a8a168f2aff57b
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-08

### Updated packages
- google-chrome(150.0.7871.100)
- librewolf(152.0.5.1)
- musescore-bin(4.7.4.260706075)
- opencode(1.17.15)
- simplex-desktop(6.5.6)
- vscode-bin(1.128.0)

### ⚠️ Failed updates
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.