### PR TITLE
auto-update:  brave(1.92.138) google-chrome(150.0.7871.114) helium-browser(0.14.4.1) ollama(0.31.2) opencode(1.17.16) zed(1.10.0)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.134
+version=1.92.138
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=fdda298329b9058c9d4e4ae0841d0e50101cbf8c2fe22deaccd44223b7b535cd
+checksum=97c744e4ded05373176fa611bf454cffae8f76a51a0e9e01930730a33c0176a1
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=150.0.7871.100
+version=150.0.7871.114
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=49b57f002ce6df5080d5f82542dc5cf11741b9379a97f1d75d7b5415ad086079
+checksum=0f19e68dca574849632e25229f15853d2beac33fa06498feed43f34628bc2d53
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.3.1
+version=0.14.4.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=ba64435dc1e50d10d6a5d3f8c31afcd6af9c517923888c7283601c25115068c0
+checksum=f7584ed0db63531119c14c8c61eed10f545f1487a561af04c732ca46c2da659a
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,7 +1,7 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.31.1
-revision=2
+version=0.31.2
+revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
 hostmakedepends="zstd libarchive"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=d297381efc136451f6fabb9dd644a67f70fe51c16815a0c4a95ff0e327a3afb4
+checksum=2c88f0f31a959bac5a3cad4cc5296ec568551d4aa79f548f554adb2b575b3133
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.15
+version=1.17.16
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=0e1353771192c7d2dc0c610d61ff70668bb8a4420dc4d9e35cfd33d7245f3e67
+checksum=802b3f4995b22a105d155ff702f83101c4c1d2584b15d066183e9b02669f6d7f
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.9.0
+version=1.10.0
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=39e553ce3a00feeb78eab63a5cb7237cb460f3c9596b1b19052ceb7b9e8ec4dd
+checksum=5c89843d69782499f35d4f1e271d2e21d3e0a860a69efac97045751c91353c9f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-09

### Updated packages
- brave(1.92.138)
- google-chrome(150.0.7871.114)
- helium-browser(0.14.4.1)
- ollama(0.31.2)
- opencode(1.17.16)
- zed(1.10.0)

### ⚠️ Failed updates
- postman

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.