### PR TITLE
auto-update:  amneziavpn(4.8.21.0) brave(1.92.139) bruno(3.5.2) google-chrome(150.0.7871.124) google-chrome-dev(152.0.7939.5) helium-browser(0.14.5.1) librewolf(152.0.6.1) mouser-bin(3.7.0) ollama(0.32.0) opencode(1.18.1) peazip(11.2.0) portainer(2.39.5)

### DIFF
--- a/srcpkgs/amneziavpn/template
+++ b/srcpkgs/amneziavpn/template
@@ -1,6 +1,6 @@
 # Template file for 'amneziavpn'
 pkgname=amneziavpn
-version=4.8.19.0
+version=4.8.21.0
 revision=1
 archs="x86_64"
 wrksrc="${pkgname}-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/amnezia-vpn/amnezia-client"
 distfiles="https://github.com/amnezia-vpn/amnezia-client/releases/download/${version}/AmneziaVPN_${version}_linux_x64.tar"
-checksum=0b3da257ec93b7f1acc9f90913a6354bf583590e01a33791cd7cf7bb3be1c3b8
+checksum=bc214d824fc5a607b27f11a8a0c0f417657d03adba65d09f142244215842a7df
 nopie=yes
 noverifyrdeps=yes
 disable_shlib_provides=yes

--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.138
+version=1.92.139
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=97c744e4ded05373176fa611bf454cffae8f76a51a0e9e01930730a33c0176a1
+checksum=6d1f8338ec0de06cdfbd7af8caf6722566d7768a805a1cc673a155a51a3a62d0
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/bruno/template
+++ b/srcpkgs/bruno/template
@@ -1,6 +1,6 @@
 # Template file for 'bruno'
 pkgname=bruno
-version=3.5.1
+version=3.5.2
 revision=1
 archs="x86_64"
 wrksrc="bruno-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://www.usebruno.com/"
 distfiles="https://github.com/usebruno/bruno/releases/download/v${version}/bruno_${version}_amd64_linux.deb"
-checksum=07e16f710ddb687d246522935a449360df2f03f32b1a739afff0a3d483e9f80f
+checksum=a31a5fc89728a592d7d1e7271a03ff8989054f7a2b9b0ca3668c64bd1cf334d1
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=152.0.7928.2
+version=152.0.7939.5
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=6cd9b8defa6fdccdc87d9fdb239f6504001e6f7ca281355172805790eb06c9cf
+checksum=a7a11289c07de94197e6ba09d89bc26019cf56bcd7491c3a56292abc54f14f5e
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=150.0.7871.114
+version=150.0.7871.124
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=0f19e68dca574849632e25229f15853d2beac33fa06498feed43f34628bc2d53
+checksum=4c636abd2ac1f6f3176f52bb4010aa37d12b5ac04c40dca9eab11992c1c75cdc
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.4.1
+version=0.14.5.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=f7584ed0db63531119c14c8c61eed10f545f1487a561af04c732ca46c2da659a
+checksum=24ce139b82def5771fab77c5304bbf0c82baf35ec5120050dab4b0634f77174e
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=152.0.5.1
+version=152.0.6.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.5-1/librewolf-152.0.5-1-linux-x86_64-package.tar.xz"
-checksum=f58d27dd41d12bd5a02a128520c07708b9a1d46a79687a0888ac6528d29ee607
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.6-1/librewolf-152.0.6-1-linux-x86_64-package.tar.xz"
+checksum=75974b75c9d8d492dd5cd742ddf3e667cb12d39ad67dcc67cb70484ccd76c9da
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/mouser-bin/template
+++ b/srcpkgs/mouser-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'mouser-bin'
 pkgname=mouser-bin
-version=3.6.0
+version=3.7.0
 revision=1
 archs="x86_64"
 wrksrc="Mouser"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/TomBadash/Mouser"
 distfiles="https://github.com/TomBadash/Mouser/releases/download/v${version}/Mouser-Linux.zip"
-checksum=c79594c8d107e1f720ce1084ff131879eb16a2a637a0b91eb71e3f665dec9d81
+checksum=9bfccf37a77e93f894ec70537e5568ba0508e7f0bcdb4a7561ac9665eb04d149
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.31.2
+version=0.32.0
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=2c88f0f31a959bac5a3cad4cc5296ec568551d4aa79f548f554adb2b575b3133
+checksum=56362d7609dfa9e35aaebb7c9cab25605d8f0528ec3d5d585dc83d6642002bab
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.17.16
+version=1.18.1
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=802b3f4995b22a105d155ff702f83101c4c1d2584b15d066183e9b02669f6d7f
+checksum=9ecce27cf529ade5f177fab478b4876b5c31d9ddc8216b994816acf192159511
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/peazip/template
+++ b/srcpkgs/peazip/template
@@ -1,6 +1,6 @@
 # Template file for 'peazip'
 pkgname=peazip
-version=11.1.0
+version=11.2.0
 revision=1
 archs="x86_64"
 wrksrc="peazip_portable-${version}.LINUX.Qt6.x86_64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://peazip.github.io/"
 distfiles="https://github.com/peazip/PeaZip/releases/download/${version}/peazip_portable-${version}.LINUX.Qt6.x86_64.tar.gz"
-checksum=4c5765523ebaf0908962c6599c26246301b0429144b49e34f7ef0f37b673c085
+checksum=e81f46854e0cf192f9eea3c51b41937ae308981f3849b8242503a77dd04bbdac
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/portainer/template
+++ b/srcpkgs/portainer/template
@@ -1,6 +1,6 @@
 # Template file for 'portainer'
 pkgname=portainer
-version=2.39.4
+version=2.39.5
 revision=1
 archs="x86_64"
 wrksrc="portainer-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Zlib"
 homepage="https://www.portainer.io/"
 distfiles="https://github.com/portainer/portainer/releases/download/${version}/portainer-${version}-linux-amd64.tar.gz"
-checksum=4082de908603a25f642c9d54c7c6da03250bb05c5bd45d26f36d5225a82e35e5
+checksum=b54b8595726a436c9de53dcaa7e60b174f8c7e98f1174a6e9bd0f23307134432
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-15

### Updated packages
- amneziavpn(4.8.21.0)
- brave(1.92.139)
- bruno(3.5.2)
- google-chrome(150.0.7871.124)
- google-chrome-dev(152.0.7939.5)
- helium-browser(0.14.5.1)
- librewolf(152.0.6.1)
- mouser-bin(3.7.0)
- ollama(0.32.0)
- opencode(1.18.1)
- peazip(11.2.0)
- portainer(2.39.5)

### ⚠️ Failed updates
- postman
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.