### PR TITLE
auto-update:  brave(1.92.140) handy-bin(0.9.3) helium-browser(0.14.6.1) opencode(1.18.2) telegram-bin(7.0.1)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.139
+version=1.92.140
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=6d1f8338ec0de06cdfbd7af8caf6722566d7768a805a1cc673a155a51a3a62d0
+checksum=7935abc3349424ecd7d8752ae5b0dc123afda484f90e954f02e057095feff581
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/handy-bin/template
+++ b/srcpkgs/handy-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'handy-bin'
 pkgname=handy-bin
-version=0.9.2
+version=0.9.3
 revision=1
 archs="x86_64"
 wrksrc="handy-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/cjpais/Handy"
 distfiles="https://github.com/cjpais/Handy/releases/download/v${version}/Handy_${version}_amd64.deb"
-checksum=5707eb750a49aa44c9606328fb370ef6d840cdb94d46aac6275b84470f0faf9a
+checksum=b160734a465c848aacec8ec3e738596cf41f19279a5048e96c740e5b6e3cb073
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.5.1
+version=0.14.6.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=24ce139b82def5771fab77c5304bbf0c82baf35ec5120050dab4b0634f77174e
+checksum=a9d335432b31e4e381c33afa03ab723c87d9707c67d989083de7467a5bdb93b2
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.1
+version=1.18.2
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=9ecce27cf529ade5f177fab478b4876b5c31d9ddc8216b994816acf192159511
+checksum=97c95e004bb73d2039f957ea33be0635ea4e22b8dceaedf8f0983765950cf1b6
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=6.9.3
+version=7.0.1
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=0299669bf1cacc8077bb34c295893ffaa702daaa11ea5d3026d67abef6c06bd6
+checksum=c4894f017ffd41f1ec0410289004a23da9d6a847c1a7ba356ab3c5b61ef2f9c9
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-07-16

### Updated packages
- brave(1.92.140)
- handy-bin(0.9.3)
- helium-browser(0.14.6.1)
- opencode(1.18.2)
- telegram-bin(7.0.1)

### ⚠️ Failed updates
- postman
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.