### PR TITLE
auto-update:  codewhale(0.9.0) floorp(12.16.2) google-chrome(150.0.7871.128) ollama(0.32.1) opencode(1.18.3)

### DIFF
--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,7 +1,7 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.8.67
-revision=2
+version=0.9.0
+revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
 hostmakedepends="libarchive"
@@ -14,6 +14,9 @@ distfiles="
  https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64
 "
 checksum="
+ a01749d4d0f4cebbf1fb62e5c9f393cb5c05b570da144176238e740552de8fca
+ 08a142fc255f23e00e049416d4ea53f7fb77e026e093ebdfad16847c0906c85b
+"
  c65d3643a6b5ffe5c8f9875f1c30df8199765b64cb9daf66b8383d45d9fcab4b
  26451e04533f75e9e74ba974a62ee681b3d00377933947180e113274e197041b
 "

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,7 +1,7 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.15.3
-revision=3
+version=12.16.2
+revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
 hostmakedepends="libarchive"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=880aef9c32a237520bfb8fba914018118243b9959901f7af20c1495917e5876f
+checksum=2fa326f7518e023548e4f0b901ba0041ff907467b66ec968330ed86dc825f9aa
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=150.0.7871.124
+version=150.0.7871.128
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=4c636abd2ac1f6f3176f52bb4010aa37d12b5ac04c40dca9eab11992c1c75cdc
+checksum=83ed59c85878ebb8fa53915ebe7066cafc58d1c04c1c95449486e6f9d99a1efb
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.0
+version=0.32.1
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=56362d7609dfa9e35aaebb7c9cab25605d8f0528ec3d5d585dc83d6642002bab
+checksum=83b1f22841eb7f6c4900c6797f960ebaa09466874442ea5b8ae3da6980d3914c
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.2
+version=1.18.3
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=97c95e004bb73d2039f957ea33be0635ea4e22b8dceaedf8f0983765950cf1b6
+checksum=60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-07-17

### Updated packages
- codewhale(0.9.0)
- floorp(12.16.2)
- google-chrome(150.0.7871.128)
- ollama(0.32.1)
- opencode(1.18.3)

### ⚠️ Failed updates
- postman
- protonmail-bridge
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.