### PR TITLE
auto-update:  brave(1.92.141) floorp(12.16.2) google-chrome(150.0.7871.128) google-chrome-dev(152.0.7953.3) helium-browser(0.14.7.1) ollama(0.32.1) opencode(1.18.3) telegram-bin(7.0.2)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.140
+version=1.92.141
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=7935abc3349424ecd7d8752ae5b0dc123afda484f90e954f02e057095feff581
+checksum=8ae740ffd38cc33c0eb16f2f1cce89fde009deb8bb2ba2ea3e514942829ae2ab
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,7 +1,7 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.15.3
-revision=3
+version=12.16.2
+revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
 hostmakedepends="libarchive"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=880aef9c32a237520bfb8fba914018118243b9959901f7af20c1495917e5876f
+checksum=2fa326f7518e023548e4f0b901ba0041ff907467b66ec968330ed86dc825f9aa
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=152.0.7939.5
+version=152.0.7953.3
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=a7a11289c07de94197e6ba09d89bc26019cf56bcd7491c3a56292abc54f14f5e
+checksum=9501fdc2fa2f6270ea572c1bdf96864ad391865bfcbb89bb7438f979150fa2c0
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=150.0.7871.124
+version=150.0.7871.128
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=4c636abd2ac1f6f3176f52bb4010aa37d12b5ac04c40dca9eab11992c1c75cdc
+checksum=83ed59c85878ebb8fa53915ebe7066cafc58d1c04c1c95449486e6f9d99a1efb
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.6.1
+version=0.14.7.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=a9d335432b31e4e381c33afa03ab723c87d9707c67d989083de7467a5bdb93b2
+checksum=24fb02bee7bbd619724bdc281ec6ae5f9c4cff63d427e9fc5448ce16ab940e7a
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.0
+version=0.32.1
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=56362d7609dfa9e35aaebb7c9cab25605d8f0528ec3d5d585dc83d6642002bab
+checksum=83b1f22841eb7f6c4900c6797f960ebaa09466874442ea5b8ae3da6980d3914c
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.2
+version=1.18.3
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=97c95e004bb73d2039f957ea33be0635ea4e22b8dceaedf8f0983765950cf1b6
+checksum=60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=7.0.1
+version=7.0.2
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=c4894f017ffd41f1ec0410289004a23da9d6a847c1a7ba356ab3c5b61ef2f9c9
+checksum=e9c888f7b18659e796dbfec830d294e11ced284ec063983bf260593c48147db2
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-07-18

### Updated packages
- brave(1.92.141)
- floorp(12.16.2)
- google-chrome(150.0.7871.128)
- google-chrome-dev(152.0.7953.3)
- helium-browser(0.14.7.1)
- ollama(0.32.1)
- opencode(1.18.3)
- telegram-bin(7.0.2)

### ⚠️ Failed updates
- postman
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.