### PR TITLE
auto-update:  vscode-bin(1.129.1) zed(1.11.3) zen-browser(1.21.8)

### DIFF
--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.128.0
+version=1.129.1
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=a9b4ce974ecc10c7456da9879763bf0a7a432710bd26c95a89a8a168f2aff57b
+checksum=722781eceec7436a095454f839f99a4e85c787aa453e9064edd96d299f024953
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.10.2
+version=1.11.3
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=ef68f4e304a944fecde442f31bcf128f29d359e3cb08edbc91c99032a7fc7a75
+checksum=483ee09c885801dd7a0230e3ccf5c463c4dbe4559927f5856fd568e7b1a32e3e
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.5
+version=1.21.8
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=0dea09bbc5fed9e1e32839f288a609b0b20eb1befed8d4f892e222a65dfaa069
+checksum=05a36657e4c9dbe700e54a2e3941f7af4656abbe330690aa74d8cf793af396f4
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-19

### Updated packages
- vscode-bin(1.129.1)
- zed(1.11.3)
- zen-browser(1.21.8)

### ⚠️ Failed updates
- librewolf
- postman
- telegram-bin
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.