### PR TITLE
auto-update:  bruno(3.5.3) dbgate(7.2.3) firefox-nightly(155.0a1) handy-bin(0.9.4) linutil(2026.07.17)

### DIFF
--- a/srcpkgs/bruno/template
+++ b/srcpkgs/bruno/template
@@ -1,6 +1,6 @@
 # Template file for 'bruno'
 pkgname=bruno
-version=3.5.2
+version=3.5.3
 revision=1
 archs="x86_64"
 wrksrc="bruno-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://www.usebruno.com/"
 distfiles="https://github.com/usebruno/bruno/releases/download/v${version}/bruno_${version}_amd64_linux.deb"
-checksum=a31a5fc89728a592d7d1e7271a03ff8989054f7a2b9b0ca3668c64bd1cf334d1
+checksum=79239a5858ce3c1e099d21aadb15d97856a09f9d07cf1c262433001273cda3e6
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/dbgate/template
+++ b/srcpkgs/dbgate/template
@@ -1,6 +1,6 @@
 # Template file for 'dbgate'
 pkgname=dbgate
-version=7.2.1
+version=7.2.3
 revision=1
 archs="x86_64"
 wrksrc="dbgate-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://dbgate.org/"
 distfiles="https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-linux_amd64.deb"
-checksum=a0e0b83ec6eb5cea479e283bddbf1a37f1b3b1a37c16ed271c4afb711bf0ef6d
+checksum=7ca2ce586b45234c513639c24bf34ac81506a35a1e7ee4ee13d20cfb1b14c0e5
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/firefox-nightly/template
+++ b/srcpkgs/firefox-nightly/template
@@ -1,6 +1,6 @@
 # Template file for 'firefox-nightly'
 pkgname=firefox-nightly
-version=154.0a1
+version=155.0a1
 revision=1
 archs="x86_64"
 wrksrc="firefox"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/firefox/channel/desktop/#nightly"
 distfiles="https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US"
-checksum=5e8ab067434475337f5d69b8bee9e573676b13cb286d070dddf67fe449c4e9fb
+checksum=ad5c64e416732386820b1779dc17d728e4df62233c07041750e9e8341a962893
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/handy-bin/template
+++ b/srcpkgs/handy-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'handy-bin'
 pkgname=handy-bin
-version=0.9.3
+version=0.9.4
 revision=1
 archs="x86_64"
 wrksrc="handy-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/cjpais/Handy"
 distfiles="https://github.com/cjpais/Handy/releases/download/v${version}/Handy_${version}_amd64.deb"
-checksum=b160734a465c848aacec8ec3e738596cf41f19279a5048e96c740e5b6e3cb073
+checksum=99ac948a7a032fb8c5c1a866388f324b71953ec955c293147b43f14c31542688
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/linutil/template
+++ b/srcpkgs/linutil/template
@@ -1,6 +1,6 @@
 # Template file for 'linutil'
 pkgname=linutil
-version=2026.05.21
+version=2026.07.17
 revision=1
 archs="x86_64"
 wrksrc="linutil-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/ChrisTitusTech/linutil"
 distfiles="https://github.com/ChrisTitusTech/linutil/releases/download/${version}/linutil"
-checksum=ec69947c1e508ae66d8950abbd103bc97ece4c4175a19da32d1b703c9379fde9
+checksum=3e7dd8da45b644e7af3ff29bfba391ebd13772865eeefb55ea88a48c74f7d1ff
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-21

### Updated packages
- bruno(3.5.3)
- dbgate(7.2.3)
- firefox-nightly(155.0a1)
- handy-bin(0.9.4)
- linutil(2026.07.17)

### ⚠️ Failed updates
- obsidian
- ollama
- onlyoffice-desktopeditors
- opencode
- opendeck
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.