### PR TITLE
auto-update:  bitwarden-bin(2026.7.0) brave(1.92.143) bruno(4.0.0) floorp(12.16.3) google-chrome(150.0.7871.186) helium-browser(0.14.8.2) insomnia(13.1.0) librewolf(153.0.3) ollama(0.32.3) opencode(1.18.4) slack-desktop(4.51.180) tabby(1.0.235) telegram-bin(7.0.5)

### DIFF
--- a/srcpkgs/bitwarden-bin/template
+++ b/srcpkgs/bitwarden-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitwarden-bin'
 pkgname=bitwarden-bin
 _pkgname=bitwarden
-version=2026.6.1
+version=2026.7.0
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz"
@@ -11,7 +11,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://bitwarden.com"
 distfiles="https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-amd64.deb"
-checksum=421bfc6d787d842406909d393c2a9044791e957aa234718ae5670e87ae4deba7
+checksum=17523257c367f299a76d3670c7e329941fdaf14a4f9321cf38b347e35453ae64
 noverifyrdeps=yes
 nostrip=yes
 noshlibs=yes

--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.141
+version=1.92.143
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=8ae740ffd38cc33c0eb16f2f1cce89fde009deb8bb2ba2ea3e514942829ae2ab
+checksum=95a0402e6da4c35683d4edcfe74043558a06fd6de5341dcccf1f148ac0534809
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/bruno/template
+++ b/srcpkgs/bruno/template
@@ -1,6 +1,6 @@
 # Template file for 'bruno'
 pkgname=bruno
-version=3.5.3
+version=4.0.0
 revision=1
 archs="x86_64"
 wrksrc="bruno-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://www.usebruno.com/"
 distfiles="https://github.com/usebruno/bruno/releases/download/v${version}/bruno_${version}_amd64_linux.deb"
-checksum=79239a5858ce3c1e099d21aadb15d97856a09f9d07cf1c262433001273cda3e6
+checksum=d3129c1115a11c95cbe3c259cc42fa05d994e579aecca7c7d4af20bf9ee54d38
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,6 +1,6 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.16.2
+version=12.16.3
 revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=2fa326f7518e023548e4f0b901ba0041ff907467b66ec968330ed86dc825f9aa
+checksum=7220509bc8ad85b2ec95336a1cda7dc31c70d1c42c1485eebfb71b246468f07c
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=150.0.7871.128
+version=150.0.7871.186
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=83ed59c85878ebb8fa53915ebe7066cafc58d1c04c1c95449486e6f9d99a1efb
+checksum=4193e00b6d5d5969ee63f7a69596868f546aa0e8cb077b3e0bf9cc1e2c719d00
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.7.1
+version=0.14.8.2
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=24fb02bee7bbd619724bdc281ec6ae5f9c4cff63d427e9fc5448ce16ab940e7a
+checksum=eca75ee82aecafa2dd2a77c447eeb213b26453afb5d315ed275190107841b6a8
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/insomnia/template
+++ b/srcpkgs/insomnia/template
@@ -1,6 +1,6 @@
 # Template file for 'insomnia'
 pkgname=insomnia
-version=13.0.2
+version=13.1.0
 revision=1
 archs="x86_64"
 wrksrc="insomnia-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://insomnia.rest/"
 distfiles="https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.deb"
-checksum=c0805c435f115c0820c4c0349384a4483752b46a9b4648e3068dc993c063a570
+checksum=480a28f5895c14be17bdbce0c7398cf592081c2a13aefd362827be2f1628d2df
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=152.0.6.1
+version=153.0.3
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/152.0.6-1/librewolf-152.0.6-1-linux-x86_64-package.tar.xz"
-checksum=75974b75c9d8d492dd5cd742ddf3e667cb12d39ad67dcc67cb70484ccd76c9da
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/153.0-3/librewolf-153.0-3-linux-x86_64-package.tar.xz"
+checksum=208a64b6c099440f1d61169b40afef1fda2b61e3c90b0b26f28036b7e21df2be
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.1
+version=0.32.3
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=83b1f22841eb7f6c4900c6797f960ebaa09466874442ea5b8ae3da6980d3914c
+checksum=2597d74fbe654ef6a37db56f771cf37d4a85c6bde4018127874e3927d3113800
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.3
+version=1.18.4
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583
+checksum=bab463c3fb3224d388bb7cfad63f38703df9cf0be2cfd2ce8cb49d886b53a174
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.50.143
+version=4.51.180
 revision=1
 archs="x86_64"
 wrksrc="slack-desktop-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Slack"
 homepage="https://slack.com/downloads"
 distfiles="https://downloads.slack-edge.com/desktop-releases/linux/x64/${version}/slack-desktop-${version}-amd64.deb"
-checksum=93ca12a293d4993ed52d280a3928bfa542d270befcdce3624366a019fbb59630
+checksum=aa45e151794703377012a9ad78f0b2152c368852e085267ae689dafb5c308ea1
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/tabby/template
+++ b/srcpkgs/tabby/template
@@ -1,6 +1,6 @@
 # Template file for 'tabby'
 pkgname=tabby
-version=1.0.234
+version=1.0.235
 revision=1
 archs="x86_64"
 wrksrc="tabby-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://tabby.sh/"
 distfiles="https://github.com/Eugeny/tabby/releases/download/v${version}/tabby-${version}-linux-x64.deb"
-checksum=1872080af06c962347c7a5411de682478e087df33eae67c2b57a517461702fd4
+checksum=eccdc34d6d17ef864d59bba1cd04d7ed4a0c27b102bdcd1ede9bdab2d693e91a
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=7.0.2
+version=7.0.5
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=e9c888f7b18659e796dbfec830d294e11ced284ec063983bf260593c48147db2
+checksum=37e23ce08333340504623042120b826f7a2a5650c831187219ab9c520740eb42
 nostrip=yes
 
 do_install() {


### PR DESCRIPTION
## Automated package updates — 2026-07-24

### Updated packages
- bitwarden-bin(2026.7.0)
- brave(1.92.143)
- bruno(4.0.0)
- floorp(12.16.3)
- google-chrome(150.0.7871.186)
- helium-browser(0.14.8.2)
- insomnia(13.1.0)
- librewolf(153.0.3)
- ollama(0.32.3)
- opencode(1.18.4)
- slack-desktop(4.51.180)
- tabby(1.0.235)
- telegram-bin(7.0.5)

### ⚠️ Failed updates
- postman
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.