### PR TITLE
auto-update:  brave(1.92.144) codewhale(0.9.1) floorp(12.16.4) google-chrome-dev(152.0.7967.2) helium-browser(0.14.9.1) mouser-bin(3.7.1)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.143
+version=1.92.144
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=95a0402e6da4c35683d4edcfe74043558a06fd6de5341dcccf1f148ac0534809
+checksum=67854d08fb57d45620341ebb4df4c9164cbd3fe5cd2c696f2b0ac8d16a3945a2
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.0
+version=0.9.1
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="
+checksum="d4bc2d1908a78c5cbe6974a6e16ca8a06690775e454e73b7f6b5548f033b5bc2 e1e215369e34668240cbbadedc91219ce6026218a5527b2abef9fae7dcb8ba05"
  a01749d4d0f4cebbf1fb62e5c9f393cb5c05b570da144176238e740552de8fca
  08a142fc255f23e00e049416d4ea53f7fb77e026e093ebdfad16847c0906c85b
 "

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,6 +1,6 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.16.3
+version=12.16.4
 revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=7220509bc8ad85b2ec95336a1cda7dc31c70d1c42c1485eebfb71b246468f07c
+checksum=da4d7887e986ac6cf49f1e06cc62e03849d8c9519e413e5c4332608648fcc533
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=152.0.7953.3
+version=152.0.7967.2
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=9501fdc2fa2f6270ea572c1bdf96864ad391865bfcbb89bb7438f979150fa2c0
+checksum=1b240eecef9575d2f1d14504001c05c726278fe4816c55a2811ed73c998d58fe
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.8.2
+version=0.14.9.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=eca75ee82aecafa2dd2a77c447eeb213b26453afb5d315ed275190107841b6a8
+checksum=72e42230684e3e313b8b1b998851a946e185f5275570d3d85174978636412ca4
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/mouser-bin/template
+++ b/srcpkgs/mouser-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'mouser-bin'
 pkgname=mouser-bin
-version=3.7.0
+version=3.7.1
 revision=1
 archs="x86_64"
 wrksrc="Mouser"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/TomBadash/Mouser"
 distfiles="https://github.com/TomBadash/Mouser/releases/download/v${version}/Mouser-Linux.zip"
-checksum=9bfccf37a77e93f894ec70537e5568ba0508e7f0bcdb4a7561ac9665eb04d149
+checksum=150f643db3d5d81a6ed09c868e50018348e07b7b02b80310932cb4e84d434ec8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-26

### Updated packages
- brave(1.92.144)
- codewhale(0.9.1)
- floorp(12.16.4)
- google-chrome-dev(152.0.7967.2)
- helium-browser(0.14.9.1)
- mouser-bin(3.7.1)

### ⚠️ Failed updates
- ollama
- onlyoffice-desktopeditors
- opencode
- opendeck
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.