### PR TITLE
auto-update:  brave(1.92.144) codewhale(0.9.1) floorp(12.16.4) google-chrome-dev(152.0.7967.2) helium-browser(0.14.9.1) mouser-bin(3.7.1) ollama(0.32.4) opencode(1.18.7) ventoy(1.1.17) vscode-bin(1.130.0) zapret2(1.0.3) zed(1.12.0) zen-browser(1.21.9)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.92.143
+version=1.92.144
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=95a0402e6da4c35683d4edcfe74043558a06fd6de5341dcccf1f148ac0534809
+checksum=67854d08fb57d45620341ebb4df4c9164cbd3fe5cd2c696f2b0ac8d16a3945a2
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.0
+version=0.9.1
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="
+checksum="d4bc2d1908a78c5cbe6974a6e16ca8a06690775e454e73b7f6b5548f033b5bc2 e1e215369e34668240cbbadedc91219ce6026218a5527b2abef9fae7dcb8ba05"
  a01749d4d0f4cebbf1fb62e5c9f393cb5c05b570da144176238e740552de8fca
  08a142fc255f23e00e049416d4ea53f7fb77e026e093ebdfad16847c0906c85b
 "

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,6 +1,6 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.16.3
+version=12.16.4
 revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=7220509bc8ad85b2ec95336a1cda7dc31c70d1c42c1485eebfb71b246468f07c
+checksum=da4d7887e986ac6cf49f1e06cc62e03849d8c9519e413e5c4332608648fcc533
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=152.0.7953.3
+version=152.0.7967.2
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=9501fdc2fa2f6270ea572c1bdf96864ad391865bfcbb89bb7438f979150fa2c0
+checksum=1b240eecef9575d2f1d14504001c05c726278fe4816c55a2811ed73c998d58fe
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.14.8.2
+version=0.14.9.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=eca75ee82aecafa2dd2a77c447eeb213b26453afb5d315ed275190107841b6a8
+checksum=72e42230684e3e313b8b1b998851a946e185f5275570d3d85174978636412ca4
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/mouser-bin/template
+++ b/srcpkgs/mouser-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'mouser-bin'
 pkgname=mouser-bin
-version=3.7.0
+version=3.7.1
 revision=1
 archs="x86_64"
 wrksrc="Mouser"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/TomBadash/Mouser"
 distfiles="https://github.com/TomBadash/Mouser/releases/download/v${version}/Mouser-Linux.zip"
-checksum=9bfccf37a77e93f894ec70537e5568ba0508e7f0bcdb4a7561ac9665eb04d149
+checksum=150f643db3d5d81a6ed09c868e50018348e07b7b02b80310932cb4e84d434ec8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.3
+version=0.32.4
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=2597d74fbe654ef6a37db56f771cf37d4a85c6bde4018127874e3927d3113800
+checksum=c00efcc236e87168e55cad9ca7c57817762dad04ccfc4565546935facf22e359
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.4
+version=1.18.7
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=bab463c3fb3224d388bb7cfad63f38703df9cf0be2cfd2ce8cb49d886b53a174
+checksum=cb5d9d6d2f8fbef0a9c975ed4494f73b2a62f4e4ffd508bcc3212da4fa76c3da
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/ventoy/template
+++ b/srcpkgs/ventoy/template
@@ -1,6 +1,6 @@
 # Template file for 'ventoy'
 pkgname=ventoy
-version=1.1.16
+version=1.1.17
 revision=1
 archs="x86_64"
 wrksrc="ventoy-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.ventoy.net"
 distfiles="https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz"
-checksum=a9ffd7bd5e26df486cafff924b8dbcb6caae20cbe2b179a009fe59ae740c7572
+checksum=7fb4ed08cef6a6b4d39dd19260d8c80291a78dfdf9af7d461571e23cbbc43805
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.129.1
+version=1.130.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=722781eceec7436a095454f839f99a4e85c787aa453e9064edd96d299f024953
+checksum=7d6ad3d3a78ac4551c14631f78d7e03c85282ab505c3ce8b1bc04e01fafe88ea
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zapret2/template
+++ b/srcpkgs/zapret2/template
@@ -1,6 +1,6 @@
 # Template file for 'zapret2'
 pkgname=zapret2
-version=1.0.2
+version=1.0.3
 revision=1
 build_style=gnu-makefile
 makedepends="LuaJIT-devel libcap-devel zlib-devel libnetfilter_queue-devel"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/bol-van/zapret2"
 distfiles="https://github.com/bol-van/zapret2/archive/refs/tags/v${version}.tar.gz"
-checksum=b778c9fda24de6d534881ce6c9ff5817ea245163d3b96dc1c1fd491704252e60
+checksum=ec84c71b7868ddb56fd85cdf30eaa258096894db2002fb6249424cc1e302c0d5
 
 do_prepare() {
     cd ipset

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.11.3
+version=1.12.0
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=483ee09c885801dd7a0230e3ccf5c463c4dbe4559927f5856fd568e7b1a32e3e
+checksum=fedaec1e617fc78fe56ff82e63ee51562902d9904b1120330c1802fec2b84315
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.8
+version=1.21.9
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=05a36657e4c9dbe700e54a2e3941f7af4656abbe330690aa74d8cf793af396f4
+checksum=f83b1467c421a2d0d53eebd2c24c747b1836f02a0d043dd8b8862392adbf6e01
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-07-27

### Updated packages
- brave(1.92.144)
- codewhale(0.9.1)
- floorp(12.16.4)
- google-chrome-dev(152.0.7967.2)
- helium-browser(0.14.9.1)
- mouser-bin(3.7.1)
- ollama(0.32.4)
- opencode(1.18.7)
- ventoy(1.1.17)
- vscode-bin(1.130.0)
- zapret2(1.0.3)
- zed(1.12.0)
- zen-browser(1.21.9)

### ⚠️ Failed updates
- amneziavpn
- librewolf
- postman
- v2rayn-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.