### PR TITLE
auto-update:  claude-desktop(1.24012.11) opencode(1.18.12)

### DIFF
--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.24012.9
+version=1.24012.11
 _release=3.2.1
 revision=1
 archs="x86_64"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v${_release}%2Bclaude${version}/claude-desktop-unofficial-${version}-${_release}-amd64.AppImage"
-checksum=5328be32bc23b3135362f7efd733bee23ff65ab74981d4823b015a31f70ecc29
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.1%2Bclaude1.24012.11/claude-desktop-unofficial-1.24012.11-3.2.1-amd64.AppImage"
+checksum=c7aa4cc54f9476d9e7b19531e9266bd379f492abcdb0b272a480315fa0442e06
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.11
+version=1.18.12
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=a4dffcc00a5a93256c6bd06aa0c984320528f564db52a1f4becd5c7de9fb59a1
+checksum=7a2e3b706306b04fbf5353b67d916b0801fcda565f9ee021bea2a77207961452
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-08-04

### Updated packages
- claude-desktop(1.24012.11)
- opencode(1.18.12)

### ⚠️ Failed updates
- amneziavpn
- postman
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.