### PR TITLE
auto-update:  dbgate(7.2.4) google-chrome(151.0.7922.75) librewolf(153.0.3.1) opencode(1.18.13)

### DIFF
--- a/srcpkgs/dbgate/template
+++ b/srcpkgs/dbgate/template
@@ -1,6 +1,6 @@
 # Template file for 'dbgate'
 pkgname=dbgate
-version=7.2.3
+version=7.2.4
 revision=1
 archs="x86_64"
 wrksrc="dbgate-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://dbgate.org/"
 distfiles="https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-linux_amd64.deb"
-checksum=7ca2ce586b45234c513639c24bf34ac81506a35a1e7ee4ee13d20cfb1b14c0e5
+checksum=2bc8fa6a36ca3ef340276dcae158dc423058774b321729a5d23f244f594d7520
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=151.0.7922.71
+version=151.0.7922.75
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=c86cafc697ecdb88259312cef47e464d1278643610500a7c9104e6bb1af3ba5c
+checksum=cb7359a53308fbe441bef6d5bdd61b408c1b40f980e8bf7d02eb311617918d10
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=153.0.1.1
+version=153.0.3.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/153.0.1-1/librewolf-153.0.1-1-linux-x86_64-package.tar.xz"
-checksum=7b56e06071ece9e711a1c811e64129a3a14775c5fe00a4b777e5cbb0b087b5b5
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/153.0.3-1/librewolf-153.0.3-1-linux-x86_64-package.tar.xz"
+checksum=15d7ff2ac24cea0b5fe4519eafc874b2514ff619c7f1e192f08927c5ae1eb163
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.12
+version=1.18.13
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=7a2e3b706306b04fbf5353b67d916b0801fcda565f9ee021bea2a77207961452
+checksum=8d500b20fed2d26e537e221895b1a575476571b4f0089bb29fb13eeb8eb9e937
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-08-05

### Updated packages
- dbgate(7.2.4)
- google-chrome(151.0.7922.75)
- librewolf(153.0.3.1)
- opencode(1.18.13)

### ⚠️ Failed updates
- amneziavpn
- postman
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.