### PR TITLE
auto-update:  chatbox(1.22.2) google-chrome(151.0.7922.108) helium-browser(0.15.2.1) opencode(1.18.15)

### DIFF
--- a/srcpkgs/chatbox/template
+++ b/srcpkgs/chatbox/template
@@ -1,6 +1,6 @@
 # Template file for 'chatbox'
 pkgname=chatbox
-version=1.22.1
+version=1.22.2
 revision=1
 archs="x86_64"
 wrksrc="chatbox-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://chatboxai.app/"
 distfiles="https://download.chatboxai.app/releases/Chatbox-${version}-x86_64.AppImage"
-checksum=8582b78e574d51431475fa561727f29db603405d93c35d7ed01fd31da0cf7ac3
+checksum=74ad8b87d5ef567fac6d6917c684e27b24be3459abae6c2a2fd22cbdd9f7a8d5
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=151.0.7922.75
+version=151.0.7922.108
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=cb7359a53308fbe441bef6d5bdd61b408c1b40f980e8bf7d02eb311617918d10
+checksum=bfb6e6d345055eb481a50db423256fa2732ce010f785a56c327e213a638efdef
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.1.1
+version=0.15.2.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=ab3df0fa79ef0609291d3dc4df876fe03bc5b98972cd303283db4f609156b37a
+checksum=4a7dcc5acbea670e5851854aac49092d6d60150d52afec2112c0a217160dbe08
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.14
+version=1.18.15
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=f23980ba2aebfbfa53948e55e213d3f2a53740fd7326553828e89ad27e970572
+checksum=d842e0e8c622c672a481b7dc6f0329009b64db96b2ba6041e56f4f93f0293b1c
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-08-07

### Updated packages
- chatbox(1.22.2)
- google-chrome(151.0.7922.108)
- helium-browser(0.15.2.1)
- opencode(1.18.15)

### ⚠️ Failed updates
- amneziavpn
- postman
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.