### PR TITLE
auto-update:  ayugram(7.0.9) brave(1.93.134) codewhale(0.9.4) google-chrome-dev(153.0.7993.0) handy-bin(0.9.5) vscode-bin(1.132.0) wild-linker(0.10.0) zed(1.14.2) zen-browser(1.21.12)

### DIFF
--- a/srcpkgs/ayugram/template
+++ b/srcpkgs/ayugram/template
@@ -1,7 +1,7 @@
 # Template file for 'ayugram'
 pkgname=ayugram
-version=6.7.8
-revision=3
+version=7.0.9
+revision=1
 wrksrc="AyuGramDesktop-${version}"
 build_style=cmake
 build_helper="qemu gir"
@@ -31,7 +31,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/AyuGram/AyuGramDesktop"
 changelog="https://github.com/AyuGram/AyuGramDesktop/releases/tag/v${version}"
 distfiles="https://github.com/AyuGram/AyuGramDesktop/releases/download/v${version}/AyuGramDesktop-${version}-full.tar.gz"
-checksum=c8de66c5568dfc3e4e309275cc858e84a61f781fe93ed967290c31b70c770b00
+checksum=79b78388e9f583582835362f3ae0694857216e4436c1f07231606105945eb2d6
 nocross=yes
 
 if [ "$XBPS_TARGET_WORDSIZE" -eq 32 ]; then

--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.93.132
+version=1.93.134
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=7bcb3b4afaada81a3cbfecc5c82ba682668562a27c541a4da06f38885288c560
+checksum=f4e933b8e13149b87f6bed8789174745809e79301eb33fab0d643b848a9fde6f
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.3
+version=0.9.4
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="e012ad7a566810fd9ad96c1008b59434120fdfabb25feee8a6394f9a9133b5dc f94a4a0367b4e150101019e7e8a6d138c53c87b20885e9e4564c1202c125e75f"
+checksum="d1654c674df40b1f14516a3dbf812bf743eb8bad2704f204e4f034696c115cad c894674802950947acb735b5b87e7a6e1c361595fdb569cf676f8885c9d87494"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=153.0.7979.3
+version=153.0.7993.0
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=85cf2aa5b14dca03421f3005f7e18b45a6395e5bc04b3368bccbf498529c8577
+checksum=b7c9fb8bbc12cf6ef785b009cc1bc592ddd7e89171bf1c6b972097bd08e3df2a
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/handy-bin/template
+++ b/srcpkgs/handy-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'handy-bin'
 pkgname=handy-bin
-version=0.9.4
+version=0.9.5
 revision=1
 archs="x86_64"
 wrksrc="handy-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/cjpais/Handy"
 distfiles="https://github.com/cjpais/Handy/releases/download/v${version}/Handy_${version}_amd64.deb"
-checksum=99ac948a7a032fb8c5c1a866388f324b71953ec955c293147b43f14c31542688
+checksum=e315105a78387525d205365f496a92e24f5578c4bdb1d609c03a955072870b29
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.131.0
+version=1.132.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=8632e6f9aed7a2c5612475559ff3d18c661d35432c226506db70444a99845731
+checksum=acdaf0fa557bda1720956ff65ca0de0965e92d68f97e2db22341984400937aed
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/wild-linker/template
+++ b/srcpkgs/wild-linker/template
@@ -1,6 +1,6 @@
 # Template file for 'wild-linker'
 pkgname=wild-linker
-version=0.9.0
+version=0.10.0
 revision=1
 archs="x86_64"
 wrksrc="wild-linker-${version}-x86_64-unknown-linux-gnu"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT OR Apache-2.0"
 homepage="https://github.com/wild-linker/wild"
 distfiles="https://github.com/wild-linker/wild/releases/download/${version}/wild-linker-${version}-x86_64-unknown-linux-gnu.tar.gz"
-checksum=deb6ee0e5caec798053ec4aafaba042e20a8edf91f08cb4d36268571cc628d3b
+checksum=641265506a7c06cfb03181b8916ab663ec8407855db6d4db7f8450667d105283
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.13.1
+version=1.14.2
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=9f5638bdf28dd15dd8d82d092577e82de6cd3d0e0c96d2658e24a63df025b9f5
+checksum=6c476103b49a87dc62c46b8cc4dca84c0458ed53537de664ebdbc99b47daee2d
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.10
+version=1.21.12
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=6a134befd30e9618f4d7e50dddb3ae721de117bab728a97c75f9e5c2123a1d0f
+checksum=47e1492bedca5ae4142f54a220559e0bef7a784fb530908f6059da766d16222f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-08

### Updated packages
- ayugram(7.0.9)
- brave(1.93.134)
- codewhale(0.9.4)
- google-chrome-dev(153.0.7993.0)
- handy-bin(0.9.5)
- vscode-bin(1.132.0)
- wild-linker(0.10.0)
- zed(1.14.2)
- zen-browser(1.21.12)

### ⚠️ Failed updates
- amneziavpn
- postman

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.