### PR TITLE
auto-update:  brave(1.93.134) chatbox(1.22.3) claude-desktop(1.26832.0) codewhale(0.9.5) google-chrome-dev(153.0.7993.0) handy-bin(0.9.5) helium-browser(0.15.3.1) heroic(2.22.1) nuclei(3.11.1) opencode(1.18.16)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.93.132
+version=1.93.134
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=7bcb3b4afaada81a3cbfecc5c82ba682668562a27c541a4da06f38885288c560
+checksum=f4e933b8e13149b87f6bed8789174745809e79301eb33fab0d643b848a9fde6f
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/chatbox/template
+++ b/srcpkgs/chatbox/template
@@ -1,6 +1,6 @@
 # Template file for 'chatbox'
 pkgname=chatbox
-version=1.22.2
+version=1.22.3
 revision=1
 archs="x86_64"
 wrksrc="chatbox-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://chatboxai.app/"
 distfiles="https://download.chatboxai.app/releases/Chatbox-${version}-x86_64.AppImage"
-checksum=74ad8b87d5ef567fac6d6917c684e27b24be3459abae6c2a2fd22cbdd9f7a8d5
+checksum=6ef9e3bee3cb4e19c771eb98c32f82db0b05cd9344834fdf3d5e7ef69e131013
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.24012.11
-_release=3.2.1
+version=1.26832.0
+_release=3.2.2
 revision=1
 archs="x86_64"
 wrksrc="claude-desktop-${version}"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.1%2Bclaude1.24012.11/claude-desktop-unofficial-1.24012.11-3.2.1-amd64.AppImage"
-checksum=c7aa4cc54f9476d9e7b19531e9266bd379f492abcdb0b272a480315fa0442e06
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.26832.0/claude-desktop-unofficial-1.26832.0-3.2.2-amd64.AppImage"
+checksum=ca2a6d0bb49e151ded5d9beff45dff41b6be9d479a4ac16a1839b460c1a2b060
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.3
+version=0.9.5
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="e012ad7a566810fd9ad96c1008b59434120fdfabb25feee8a6394f9a9133b5dc f94a4a0367b4e150101019e7e8a6d138c53c87b20885e9e4564c1202c125e75f"
+checksum="19986b12c005ad6e140203595254c611933b85a86b3affcc63c5440afa388f27 19986b12c005ad6e140203595254c611933b85a86b3affcc63c5440afa388f27"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=153.0.7979.3
+version=153.0.7993.0
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=85cf2aa5b14dca03421f3005f7e18b45a6395e5bc04b3368bccbf498529c8577
+checksum=b7c9fb8bbc12cf6ef785b009cc1bc592ddd7e89171bf1c6b972097bd08e3df2a
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/handy-bin/template
+++ b/srcpkgs/handy-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'handy-bin'
 pkgname=handy-bin
-version=0.9.4
+version=0.9.5
 revision=1
 archs="x86_64"
 wrksrc="handy-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/cjpais/Handy"
 distfiles="https://github.com/cjpais/Handy/releases/download/v${version}/Handy_${version}_amd64.deb"
-checksum=99ac948a7a032fb8c5c1a866388f324b71953ec955c293147b43f14c31542688
+checksum=e315105a78387525d205365f496a92e24f5578c4bdb1d609c03a955072870b29
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.2.1
+version=0.15.3.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=4a7dcc5acbea670e5851854aac49092d6d60150d52afec2112c0a217160dbe08
+checksum=6420a6fe9ae481881b0c75ba3813d6be8204efb83b21842961da9cfcf9c8ad25
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/heroic/template
+++ b/srcpkgs/heroic/template
@@ -1,6 +1,6 @@
 # Template file for 'heroic'
 pkgname=heroic
-version=2.22.0
+version=2.22.1
 revision=1
 archs="x86_64"
 wrksrc="heroic-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://heroicgameslauncher.com/"
 distfiles="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v${version}/Heroic-${version}-linux-amd64.deb"
-checksum=4c8585ad7c7a76bd3c8058aa995b9064f457603f3b6afbd9114433cf4af7ecd2
+checksum=2f3bdb663b48144b7804c30724765dc4bdc76357b7cd5f35a5dadf3030f6a948
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/nuclei/template
+++ b/srcpkgs/nuclei/template
@@ -1,6 +1,6 @@
 # Template file for 'nuclei'
 pkgname=nuclei
-version=3.11.0
+version=3.11.1
 revision=1
 archs="x86_64"
 wrksrc="nuclei-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/projectdiscovery/nuclei"
 distfiles="https://github.com/projectdiscovery/nuclei/releases/download/v${version}/nuclei_${version}_linux_amd64.zip"
-checksum=dc238d6040813e14fc30514dac5a2eb1b430c694f3ca99eee2a5097e55076283
+checksum=ea63d4ae232808cd7c6bc00d0142428e231fab59dae01042246097d195835ab6
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.15
+version=1.18.16
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=d842e0e8c622c672a481b7dc6f0329009b64db96b2ba6041e56f4f93f0293b1c
+checksum=286e07355df06738c1905955be15b7fbc10a7b12d931de9394a6f7597246750b
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-08-10

### Updated packages
- brave(1.93.134)
- chatbox(1.22.3)
- claude-desktop(1.26832.0)
- codewhale(0.9.5)
- google-chrome-dev(153.0.7993.0)
- handy-bin(0.9.5)
- helium-browser(0.15.3.1)
- heroic(2.22.1)
- nuclei(3.11.1)
- opencode(1.18.16)

### ⚠️ Failed updates
- amneziavpn
- postman
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.