### PR TITLE
auto-update:  localsend(1.18.0) obsidian(1.13.6) ollama(0.32.8)

### DIFF
--- a/srcpkgs/localsend/template
+++ b/srcpkgs/localsend/template
@@ -1,6 +1,6 @@
 # Template file for 'localsend'
 pkgname=localsend
-version=1.17.0
+version=1.18.0
 revision=1
 archs="x86_64"
 wrksrc="localsend-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://localsend.org/"
 distfiles="https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}-linux-x86-64.deb"
-checksum=b0244b2c3eacb2a81d61b2662534d6036ab37ace10d6782da36b630c222fa04c
+checksum=dae68192ad43a59a68df06454eb5fa4e9a9f86a343fe430165efd8b18863d0f4
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/obsidian/template
+++ b/srcpkgs/obsidian/template
@@ -1,6 +1,6 @@
 # Template file for 'obsidian'
 pkgname=obsidian
-version=1.13.4
+version=1.13.6
 revision=1
 archs="x86_64"
 wrksrc="obsidian-${version}"
@@ -13,7 +13,7 @@ license="custom:Obsidian-EULA"
 homepage="https://obsidian.md"
 changelog="https://obsidian.md/changelog"
 distfiles="https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/Obsidian-${version}.AppImage>obsidian-${version}.AppImage"
-checksum=b66f01d2a6afbb6b7abd93e4b5c6602645f03c16ad2d6dd49fd5a90dddd87872
+checksum=7f1d5829263c93ca9d166c2be7aba941ac52f50861a46adda72105411a7b541e
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.6
+version=0.32.8
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=dec2fa50d24e6868ca3c4c977d69d059399372105f951a9acc320a5a79aadcfc
+checksum=c10b76c39cb72908cc92dff314e80e32736c03f1287efb4b39e0b70fd600cc64
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-11

### Updated packages
- localsend(1.18.0)
- obsidian(1.13.6)
- ollama(0.32.8)

### ⚠️ Failed updates
- amneziavpn
- postman
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.