### PR TITLE
auto-update:  claude-desktop(1.28929.0) google-chrome(151.0.7922.137) helium-browser(0.15.4.1) localsend(1.18.0) obsidian(1.13.6) ollama(0.32.9)

### DIFF
--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.26832.0
+version=1.28929.0
 _release=3.2.2
 revision=1
 archs="x86_64"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.26832.0/claude-desktop-unofficial-1.26832.0-3.2.2-amd64.AppImage"
-checksum=ca2a6d0bb49e151ded5d9beff45dff41b6be9d479a4ac16a1839b460c1a2b060
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.28929.0/claude-desktop-unofficial-1.28929.0-3.2.2-amd64.AppImage"
+checksum=ef067ed0a69fd0789899d5beb9dea8fecfe8bb3c7321782b29bf4771b5adb8cc
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=151.0.7922.108
+version=151.0.7922.137
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=bfb6e6d345055eb481a50db423256fa2732ce010f785a56c327e213a638efdef
+checksum=e6dabf044cf9cd0279cfe86efa431682c18bfc06d06339ce055aaa87ae871727
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.3.1
+version=0.15.4.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=6420a6fe9ae481881b0c75ba3813d6be8204efb83b21842961da9cfcf9c8ad25
+checksum=877cb166731bfc41ef3c900b4252601d455850db1fbafd299dec207fa2bab31f
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/localsend/template
+++ b/srcpkgs/localsend/template
@@ -1,6 +1,6 @@
 # Template file for 'localsend'
 pkgname=localsend
-version=1.17.0
+version=1.18.0
 revision=1
 archs="x86_64"
 wrksrc="localsend-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://localsend.org/"
 distfiles="https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}-linux-x86-64.deb"
-checksum=b0244b2c3eacb2a81d61b2662534d6036ab37ace10d6782da36b630c222fa04c
+checksum=dae68192ad43a59a68df06454eb5fa4e9a9f86a343fe430165efd8b18863d0f4
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/obsidian/template
+++ b/srcpkgs/obsidian/template
@@ -1,6 +1,6 @@
 # Template file for 'obsidian'
 pkgname=obsidian
-version=1.13.4
+version=1.13.6
 revision=1
 archs="x86_64"
 wrksrc="obsidian-${version}"
@@ -13,7 +13,7 @@ license="custom:Obsidian-EULA"
 homepage="https://obsidian.md"
 changelog="https://obsidian.md/changelog"
 distfiles="https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/Obsidian-${version}.AppImage>obsidian-${version}.AppImage"
-checksum=b66f01d2a6afbb6b7abd93e4b5c6602645f03c16ad2d6dd49fd5a90dddd87872
+checksum=7f1d5829263c93ca9d166c2be7aba941ac52f50861a46adda72105411a7b541e
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.6
+version=0.32.9
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=dec2fa50d24e6868ca3c4c977d69d059399372105f951a9acc320a5a79aadcfc
+checksum=5d747a43369f61e38f20b5a39fcc5c90647e562cdc61e2e56034f1c5b113d540
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-12

### Updated packages
- claude-desktop(1.28929.0)
- google-chrome(151.0.7922.137)
- helium-browser(0.15.4.1)
- localsend(1.18.0)
- obsidian(1.13.6)
- ollama(0.32.9)

### ⚠️ Failed updates
- amneziavpn
- postman
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.