### PR TITLE
auto-update:  firefox-nightly(156.0a1) google-chrome(151.0.7922.137) google-chrome-dev(153.0.8003.0) librewolf(153.0.4.1)

### DIFF
--- a/srcpkgs/firefox-nightly/template
+++ b/srcpkgs/firefox-nightly/template
@@ -1,6 +1,6 @@
 # Template file for 'firefox-nightly'
 pkgname=firefox-nightly
-version=155.0a1
+version=156.0a1
 revision=1
 archs="x86_64"
 wrksrc="firefox"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/firefox/channel/desktop/#nightly"
 distfiles="https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US"
-checksum=ad5c64e416732386820b1779dc17d728e4df62233c07041750e9e8341a962893
+checksum=dd1aa52c6479b6acdf520f27d95bbfd10b571437f53c727fc4f7af9440022035
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=153.0.7993.0
+version=153.0.8003.0
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=b7c9fb8bbc12cf6ef785b009cc1bc592ddd7e89171bf1c6b972097bd08e3df2a
+checksum=0ac60fd2e79f23e30d6468c55b493a572df1b03c6845138b22d976baf5a2a2fc
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=151.0.7922.108
+version=151.0.7922.137
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=bfb6e6d345055eb481a50db423256fa2732ce010f785a56c327e213a638efdef
+checksum=e6dabf044cf9cd0279cfe86efa431682c18bfc06d06339ce055aaa87ae871727
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=153.0.3.1
+version=153.0.4.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/153.0.3-1/librewolf-153.0.3-1-linux-x86_64-package.tar.xz"
-checksum=15d7ff2ac24cea0b5fe4519eafc874b2514ff619c7f1e192f08927c5ae1eb163
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/153.0.4-1/librewolf-153.0.4-1-linux-x86_64-package.tar.xz"
+checksum=28fbf8e3e175a1fabb2f625ae9733802d22eb480927c9cfa47b5ef92f947e58d
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-14

### Updated packages
- firefox-nightly(156.0a1)
- google-chrome(151.0.7922.137)
- google-chrome-dev(153.0.8003.0)
- librewolf(153.0.4.1)

### ⚠️ Failed updates
- amneziavpn
- aniliberty
- appimagepool
- ayugram
- bitwarden-bin
- brave
- bruno
- caprine
- chatbox
- chiaki-ng
- claude-desktop
- codewhale
- copyq
- cryptomator
- curlie
- darkly
- dbgate
- espflash
- ferdium
- floorp
- github-desktop
- handy-bin
- happ
- hck
- helium-browser
- heroic
- hiddify
- insomnia
- jnv
- kmon
- koala-clash
- kubeshark
- linutil
- localsend
- logitune
- losslesscut
- lpm
- macchina
- mouser-bin
- musescore-bin
- noi-bin
- nuclei
- obsidian
- ollama
- onlyoffice-desktopeditors
- opencode
- opendeck
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.