### PR TITLE
auto-update:  codewhale(0.9.7) dbgate(7.2.5) kubeshark(53.4.0) ollama(0.32.13)

### DIFF
--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.6
+version=0.9.7
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="3f8610f8d4c283fffdd38a9a4bd041b512a7e3cadf859d9b25ad097b50eab7e6 3f8610f8d4c283fffdd38a9a4bd041b512a7e3cadf859d9b25ad097b50eab7e6"
+checksum="74bcfb52b5b513fae608adbb8ed3d0303ef02714cc7836f5b7fd4704a2039891 74bcfb52b5b513fae608adbb8ed3d0303ef02714cc7836f5b7fd4704a2039891"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/dbgate/template
+++ b/srcpkgs/dbgate/template
@@ -1,6 +1,6 @@
 # Template file for 'dbgate'
 pkgname=dbgate
-version=7.2.4
+version=7.2.5
 revision=1
 archs="x86_64"
 wrksrc="dbgate-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://dbgate.org/"
 distfiles="https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-linux_amd64.deb"
-checksum=2bc8fa6a36ca3ef340276dcae158dc423058774b321729a5d23f244f594d7520
+checksum=00dfb10213cb596ee7489b415bcd0c98f3bbf1809cd62bb117394721686cfab8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/kubeshark/template
+++ b/srcpkgs/kubeshark/template
@@ -1,6 +1,6 @@
 # Template file for 'kubeshark'
 pkgname=kubeshark
-version=53.3.0
+version=53.4.0
 revision=1
 archs="x86_64"
 wrksrc="kubeshark-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/kubeshark/kubeshark"
 distfiles="https://github.com/kubeshark/kubeshark/releases/download/v${version}/kubeshark_linux_amd64"
-checksum=4e1715b92f2a3c4a63a80e1cc31a51ce43d93b9e0b18bf3968730e5ac678e23e
+checksum=ef604fe6733692371c879abe21b20f2fe5a4f4e27a0a76b5eacdf7fe9ab62bf2
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.9
+version=0.32.13
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=5d747a43369f61e38f20b5a39fcc5c90647e562cdc61e2e56034f1c5b113d540
+checksum=0fd1dece38a1c6242e8013ce20b597345c5de072ae6b320160edb0e729ef1de1
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-15

### Updated packages
- codewhale(0.9.7)
- dbgate(7.2.5)
- kubeshark(53.4.0)
- ollama(0.32.13)

### ⚠️ Failed updates
- amneziavpn
- postman
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.