### PR TITLE
auto-update:  codewhale(0.9.8) helium-browser(0.15.5.1) ollama(0.32.14)

### DIFF
--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.7
+version=0.9.8
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="74bcfb52b5b513fae608adbb8ed3d0303ef02714cc7836f5b7fd4704a2039891 74bcfb52b5b513fae608adbb8ed3d0303ef02714cc7836f5b7fd4704a2039891"
+checksum="f3a035de438b5904e9f032d330990987bbd19843ae1cb5c1e37d8b1b782ec1ea f3a035de438b5904e9f032d330990987bbd19843ae1cb5c1e37d8b1b782ec1ea"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.4.1
+version=0.15.5.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=877cb166731bfc41ef3c900b4252601d455850db1fbafd299dec207fa2bab31f
+checksum=502d8ba6695197b57e2d18688ea8395654bb56932913df66e3fef2887d4a00ce
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.13
+version=0.32.14
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=0fd1dece38a1c6242e8013ce20b597345c5de072ae6b320160edb0e729ef1de1
+checksum=c620917a71e146ab3a7f893084f066069c4c65d144ef8379a91c3cbe8b27de8f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-17

### Updated packages
- codewhale(0.9.8)
- helium-browser(0.15.5.1)
- ollama(0.32.14)

### ⚠️ Failed updates
- amneziavpn
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.