### PR TITLE
auto-update:  claude-desktop(1.30096.5) codewhale(0.9.8) helium-browser(0.15.5.1) librewolf(154.0.2) ollama(0.32.14) wild-linker(0.10.0) zed(1.15.0) zen-browser(1.21.14)

### DIFF
--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.30096.1
+version=1.30096.5
 _release=3.2.2
 revision=1
 archs="x86_64"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.30096.1/claude-desktop-unofficial-1.30096.1-3.2.2-amd64.AppImage"
-checksum=60fe79f0db4e6cf8b6c8e43f4ee12a7e25039378a05338a00aade554a26480bb
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.30096.5/claude-desktop-unofficial-1.30096.5-3.2.2-amd64.AppImage"
+checksum=a14dc31d9c784e590319f761246781cbb033c31bc4e21dff647ca054f20f4087
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.7
+version=0.9.8
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="74bcfb52b5b513fae608adbb8ed3d0303ef02714cc7836f5b7fd4704a2039891 74bcfb52b5b513fae608adbb8ed3d0303ef02714cc7836f5b7fd4704a2039891"
+checksum="f3a035de438b5904e9f032d330990987bbd19843ae1cb5c1e37d8b1b782ec1ea f3a035de438b5904e9f032d330990987bbd19843ae1cb5c1e37d8b1b782ec1ea"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.4.1
+version=0.15.5.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=877cb166731bfc41ef3c900b4252601d455850db1fbafd299dec207fa2bab31f
+checksum=502d8ba6695197b57e2d18688ea8395654bb56932913df66e3fef2887d4a00ce
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=153.0.4.1
+version=154.0.2
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/153.0.4-1/librewolf-153.0.4-1-linux-x86_64-package.tar.xz"
-checksum=28fbf8e3e175a1fabb2f625ae9733802d22eb480927c9cfa47b5ef92f947e58d
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/154.0-2/librewolf-154.0-2-linux-x86_64-package.tar.xz"
+checksum=b89b3af9074b9a9512843deb2cc2c633b9ee279cefe45b9da8d41db0f377bc5a
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.13
+version=0.32.14
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=0fd1dece38a1c6242e8013ce20b597345c5de072ae6b320160edb0e729ef1de1
+checksum=c620917a71e146ab3a7f893084f066069c4c65d144ef8379a91c3cbe8b27de8f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/wild-linker/template
+++ b/srcpkgs/wild-linker/template
@@ -1,6 +1,6 @@
 # Template file for 'wild-linker'
 pkgname=wild-linker
-version=0.9.0
+version=0.10.0
 revision=1
 archs="x86_64"
 wrksrc="wild-linker-${version}-x86_64-unknown-linux-gnu"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT OR Apache-2.0"
 homepage="https://github.com/wild-linker/wild"
 distfiles="https://github.com/wild-linker/wild/releases/download/${version}/wild-linker-${version}-x86_64-unknown-linux-gnu.tar.gz"
-checksum=deb6ee0e5caec798053ec4aafaba042e20a8edf91f08cb4d36268571cc628d3b
+checksum=641265506a7c06cfb03181b8916ab663ec8407855db6d4db7f8450667d105283
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.13.1
+version=1.15.0
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=9f5638bdf28dd15dd8d82d092577e82de6cd3d0e0c96d2658e24a63df025b9f5
+checksum=abf751395da92fcac783e1ec59e9812ac4c4ebb33a27f7f51059edde1aee99f9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.10
+version=1.21.14
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=6a134befd30e9618f4d7e50dddb3ae721de117bab728a97c75f9e5c2123a1d0f
+checksum=b3a5bb782d9403dce8cf4cde3d61daed64548568058862eaeb9e045c212b7ee0
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-18

### Updated packages
- claude-desktop(1.30096.5)
- codewhale(0.9.8)
- helium-browser(0.15.5.1)
- librewolf(154.0.2)
- ollama(0.32.14)
- wild-linker(0.10.0)
- zed(1.15.0)
- zen-browser(1.21.14)

### ⚠️ Failed updates
- amneziavpn
- postman

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.