### PR TITLE
auto-update:  claude-desktop(1.32885.1) codewhale(0.9.9) google-chrome(151.0.7922.169)

### DIFF
--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.30096.5
+version=1.32885.1
 _release=3.2.2
 revision=1
 archs="x86_64"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.30096.5/claude-desktop-unofficial-1.30096.5-3.2.2-amd64.AppImage"
-checksum=a14dc31d9c784e590319f761246781cbb033c31bc4e21dff647ca054f20f4087
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.2%2Bclaude1.32885.1/claude-desktop-unofficial-1.32885.1-3.2.2-amd64.AppImage"
+checksum=ecde0af672e45b363f16bcba17bc22050bbaa402af36a97cdfdf61417a32a988
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.8
+version=0.9.9
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="f3a035de438b5904e9f032d330990987bbd19843ae1cb5c1e37d8b1b782ec1ea f3a035de438b5904e9f032d330990987bbd19843ae1cb5c1e37d8b1b782ec1ea"
+checksum="72acd677549d9f95fe55acb576d38fa4e87d4a2e722bed4270e243654af61f7d 72acd677549d9f95fe55acb576d38fa4e87d4a2e722bed4270e243654af61f7d"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=151.0.7922.137
+version=151.0.7922.169
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=e6dabf044cf9cd0279cfe86efa431682c18bfc06d06339ce055aaa87ae871727
+checksum=6572478310553cb25fdcb4ba2fb5459b472c2c765f5f68e9837d4964e8a87f1e
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-19

### Updated packages
- claude-desktop(1.32885.1)
- codewhale(0.9.9)
- google-chrome(151.0.7922.169)

### ⚠️ Failed updates
- amneziavpn
- postman
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.