### PR TITLE
auto-update:  arianna(26.08.0) bitwarden-bin(2026.8.0) bruno(4.1.0) codewhale(0.9.10) ferdium(7.2.1) floorp(12.17.0) google-chrome(151.0.7922.173) helium-browser(0.15.6.1)

### DIFF
--- a/srcpkgs/arianna/template
+++ b/srcpkgs/arianna/template
@@ -1,6 +1,6 @@
 # Template file for 'arianna'
 pkgname=arianna
-version=26.04.3
+version=26.08.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -18,6 +18,6 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://apps.kde.org/arianna/"
 distfiles="https://download.kde.org/stable/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=ad34fbc90ffc5e3676c7d316f402095cee3739d2e382985dd3da158cc0a2398e
+checksum=c39b09785b0f5ec882451e14010e09078e5797483fd5293c2dfd259573ac5f95
 noverifyrdeps=yes
 disable_shlib_provides=yes

--- a/srcpkgs/bitwarden-bin/template
+++ b/srcpkgs/bitwarden-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitwarden-bin'
 pkgname=bitwarden-bin
 _pkgname=bitwarden
-version=2026.7.0
+version=2026.8.0
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz"
@@ -11,7 +11,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://bitwarden.com"
 distfiles="https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-amd64.deb"
-checksum=17523257c367f299a76d3670c7e329941fdaf14a4f9321cf38b347e35453ae64
+checksum=720ecc392eef1992780af2aaabd4733916807155c8ee217ed67f3f93287bb415
 noverifyrdeps=yes
 nostrip=yes
 noshlibs=yes

--- a/srcpkgs/bruno/template
+++ b/srcpkgs/bruno/template
@@ -1,6 +1,6 @@
 # Template file for 'bruno'
 pkgname=bruno
-version=4.0.0
+version=4.1.0
 revision=1
 archs="x86_64"
 wrksrc="bruno-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://www.usebruno.com/"
 distfiles="https://github.com/usebruno/bruno/releases/download/v${version}/bruno_${version}_amd64_linux.deb"
-checksum=d3129c1115a11c95cbe3c259cc42fa05d994e579aecca7c7d4af20bf9ee54d38
+checksum=164f5181df081e493229306f00f1b68772a544c1ebc22c46f0eb6836f8a251f8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.9
+version=0.9.10
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="72acd677549d9f95fe55acb576d38fa4e87d4a2e722bed4270e243654af61f7d 72acd677549d9f95fe55acb576d38fa4e87d4a2e722bed4270e243654af61f7d"
+checksum="ed02522881d503dfa3b21dcb943c1320862c3a347ab573b170f1d82f91f1014b ed02522881d503dfa3b21dcb943c1320862c3a347ab573b170f1d82f91f1014b"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ferdium/template
+++ b/srcpkgs/ferdium/template
@@ -1,6 +1,6 @@
 # Template file for 'ferdium'
 pkgname=ferdium
-version=7.2.0
+version=7.2.1
 revision=1
 archs="x86_64"
 wrksrc="ferdium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://ferdium.org/"
 distfiles="https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-amd64.deb"
-checksum=1a4f52c1d93a8c3a0df14ce674f9e8b25cebbcdfbb1f9cbffc73de0791aa118f
+checksum=a3518a164235199b0edf3e1e7f5d0d3d3d9118ce1ff175191368f438fe21e08a
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,6 +1,6 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.16.4
+version=12.17.0
 revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=da4d7887e986ac6cf49f1e06cc62e03849d8c9519e413e5c4332608648fcc533
+checksum=7aa1f4df38d991fb9bb8ebade488481fb784ff1efaa77c359e1aba44d88487b9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=151.0.7922.169
+version=151.0.7922.173
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=6572478310553cb25fdcb4ba2fb5459b472c2c765f5f68e9837d4964e8a87f1e
+checksum=878e5ab495b8a694980fca61bc09b37e651ccedce2291c73434d16e48a2646fd
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.5.1
+version=0.15.6.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=502d8ba6695197b57e2d18688ea8395654bb56932913df66e3fef2887d4a00ce
+checksum=3aa5cc1193a816ee8d640a3375edc0a6335672f8af208b48c9e1b41db003a435
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"


### PR DESCRIPTION
## Automated package updates — 2026-08-21

### Updated packages
- arianna(26.08.0)
- bitwarden-bin(2026.8.0)
- bruno(4.1.0)
- codewhale(0.9.10)
- ferdium(7.2.1)
- floorp(12.17.0)
- google-chrome(151.0.7922.173)
- helium-browser(0.15.6.1)

### ⚠️ Failed updates
- amneziavpn
- localsend
- logitune
- losslesscut
- lpm
- macchina
- mouser-bin
- musescore-bin
- noi-bin
- nuclei
- obsidian
- ollama
- onlyoffice-desktopeditors
- opencode
- opendeck
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.