### PR TITLE
auto-update:  brave(1.93.138) google-chrome-dev(154.0.8013.2) localsend(1.18.2) ollama(0.32.15) opencode(1.18.21)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.93.137
+version=1.93.138
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=9661795c4b961ac1697fe4fa8cadf958b9c30e39e4c8db8f3bb747679c86c2ef
+checksum=8c4038e3956088cbf8f658a5e39e1a88b9f710478a8449c94d1c356d8bddc82c
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=153.0.8003.0
+version=154.0.8013.2
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=0ac60fd2e79f23e30d6468c55b493a572df1b03c6845138b22d976baf5a2a2fc
+checksum=f596bc5cf668fe5e49df7820381d921b8763438e21cacd681ccbe7a9efe6f526
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/localsend/template
+++ b/srcpkgs/localsend/template
@@ -1,6 +1,6 @@
 # Template file for 'localsend'
 pkgname=localsend
-version=1.18.0
+version=1.18.2
 revision=1
 archs="x86_64"
 wrksrc="localsend-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://localsend.org/"
 distfiles="https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}-linux-x86-64.deb"
-checksum=dae68192ad43a59a68df06454eb5fa4e9a9f86a343fe430165efd8b18863d0f4
+checksum=cc42a4f3eacdcb25ec31f0016b1272acb003145ab30484db8965450e20c72cd2
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.32.14
+version=0.32.15
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=c620917a71e146ab3a7f893084f066069c4c65d144ef8379a91c3cbe8b27de8f
+checksum=50539c5fe9bf85887733355098dcdb266b433cb8c73fa180713417e9ed6e42bb
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.19
+version=1.18.21
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=7bb35487c55f9957f5d91ae60be6fa49fc8f74629c210c1719ed75fdbf7e2bd9
+checksum=d910c3ed7613bb5791a328904615d41cc25b7d3a6b470e3199ab0426a995b38a
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"


### PR DESCRIPTION
## Automated package updates — 2026-08-22

### Updated packages
- brave(1.93.138)
- google-chrome-dev(154.0.8013.2)
- localsend(1.18.2)
- ollama(0.32.15)
- opencode(1.18.21)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- postman
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.