### PR TITLE
auto-update:  codewhale(0.9.11) ferdium(7.2.2) koala-clash(1.4.0)

### DIFF
--- a/srcpkgs/codewhale/template
+++ b/srcpkgs/codewhale/template
@@ -1,6 +1,6 @@
 # Template file for 'codewhale'
 pkgname=codewhale
-version=0.9.10
+version=0.9.11
 revision=1
 archs="x86_64"
 wrksrc="codewhale-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Hmbown/CodeWhale"
 distfiles="https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-linux-x64 https://github.com/Hmbown/CodeWhale/releases/download/v${version}/codewhale-tui-linux-x64"
-checksum="ed02522881d503dfa3b21dcb943c1320862c3a347ab573b170f1d82f91f1014b ed02522881d503dfa3b21dcb943c1320862c3a347ab573b170f1d82f91f1014b"
+checksum="c02969556e51e138afa3fe9c97a1359878cd3d1986b1ce1f5fa96c93c6909416 c02969556e51e138afa3fe9c97a1359878cd3d1986b1ce1f5fa96c93c6909416"
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ferdium/template
+++ b/srcpkgs/ferdium/template
@@ -1,6 +1,6 @@
 # Template file for 'ferdium'
 pkgname=ferdium
-version=7.2.1
+version=7.2.2
 revision=1
 archs="x86_64"
 wrksrc="ferdium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://ferdium.org/"
 distfiles="https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-amd64.deb"
-checksum=a3518a164235199b0edf3e1e7f5d0d3d3d9118ce1ff175191368f438fe21e08a
+checksum=cd325656fec21c41f74e0d5b0eaa7107e2a2adaa258b58d3bd0f615e7dcc3960
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/koala-clash/template
+++ b/srcpkgs/koala-clash/template
@@ -1,6 +1,6 @@
 # Template file for 'koala-clash'
 pkgname=koala-clash
-version=1.3.1
+version=1.4.0
 revision=1
 archs="x86_64"
 wrksrc="koala-clash-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Proprietary"
 homepage="https://github.com/coolcoala/koala-clash"
 distfiles="https://github.com/coolcoala/koala-clash/releases/download/${version}/Koala.Clash_x86_64.rpm"
-checksum=c03afc8f8cd5eb8780f4e5a03911cec9e60efdbce0956cd5dbebd06f41d87831
+checksum=2710137d3109701f6cf92bc8669111cc0db4068b3d25feb0fa7e2ac72437c61e
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-24

### Updated packages
- codewhale(0.9.11)
- ferdium(7.2.2)
- koala-clash(1.4.0)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- openlogi
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.