### PR TITLE
auto-update:  darkly(0.5.39) handy-bin(0.9.6) happ(4.1.1) helium-browser(0.15.7.1)

### DIFF
--- a/srcpkgs/darkly/template
+++ b/srcpkgs/darkly/template
@@ -1,6 +1,6 @@
 # Template file for 'darkly'
 pkgname=darkly
-version=0.5.38
+version=0.5.39
 revision=1
 wrksrc="Darkly-${version}"
 build_style=cmake
@@ -20,4 +20,4 @@ maintainer="Artem Kabanov <oloreas@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/Bali10050/Darkly"
 distfiles="https://github.com/Bali10050/Darkly/archive/refs/tags/v${version}.tar.gz"
-checksum=6ffb293b9b109fe4a4f8aad20027edb640f063fbc5e7b3621ec58762e42f4bbb
+checksum=5fed786f78ac3a6153e99920e722c981348c01fc781fb511371f6bfedee0f0c2

--- a/srcpkgs/handy-bin/template
+++ b/srcpkgs/handy-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'handy-bin'
 pkgname=handy-bin
-version=0.9.5
+version=0.9.6
 revision=1
 archs="x86_64"
 wrksrc="handy-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/cjpais/Handy"
 distfiles="https://github.com/cjpais/Handy/releases/download/v${version}/Handy_${version}_amd64.deb"
-checksum=e315105a78387525d205365f496a92e24f5578c4bdb1d609c03a955072870b29
+checksum=427eb225b37c49a40591c96f1d851ac58f328cddd28c18493dbd52ed5dd92a21
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/happ/template
+++ b/srcpkgs/happ/template
@@ -1,7 +1,7 @@
 # Template file for 'happ'
 pkgname=happ
-version=3.3.6
-revision=2
+version=4.1.1
+revision=1
 archs="x86_64"
 wrksrc="happ-${version}"
 hostmakedepends="tar xz zstd"
@@ -10,7 +10,7 @@ maintainer="Artem Kabanov <oloreas@gmail.com>"
 license="custom:Freeware"
 homepage="https://happ.su"
 distfiles="https://github.com/Happ-proxy/happ-desktop/releases/download/${version}/Happ.linux.x64.deb"
-checksum=a7dac51277387bfe1049b1ad40f40f2e74af233a5eab020b5be1a622effc46a4
+checksum=2cf3fe06f132537263c96881a391cce48310aeec0748b6741a4357b0a62dcdb8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.6.1
+version=0.15.7.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=3aa5cc1193a816ee8d640a3375edc0a6335672f8af208b48c9e1b41db003a435
+checksum=fb318419f848899584f265186f71eb92833bade14131d7d7960c372964f44fdf
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"


### PR DESCRIPTION
## Automated package updates — 2026-08-25

### Updated packages
- darkly(0.5.39)
- handy-bin(0.9.6)
- happ(4.1.1)
- helium-browser(0.15.7.1)

### ⚠️ Failed updates
- amneziavpn
- macchina
- mouser-bin
- musescore-bin
- noi-bin
- nuclei
- obsidian
- ollama
- onlyoffice-desktopeditors
- opencode
- opendeck
- openlogi
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.