### PR TITLE
auto-update:  firefox-nightly(157.0a1) google-chrome-dev(154.0.8025.0) librewolf(154.0.1.3)

### DIFF
--- a/srcpkgs/firefox-nightly/template
+++ b/srcpkgs/firefox-nightly/template
@@ -1,6 +1,6 @@
 # Template file for 'firefox-nightly'
 pkgname=firefox-nightly
-version=156.0a1
+version=157.0a1
 revision=1
 archs="x86_64"
 wrksrc="firefox"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/firefox/channel/desktop/#nightly"
 distfiles="https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US"
-checksum=e469bba2e6503254de42a8b3bbea34baaa586a3f12f8ed96bbc06493ba1e8f13
+checksum=02d5338a073ea5c6eeb69dc17a4d878fcf55c6d41ab7d34b806ae6589dc9bd28
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=154.0.8013.2
+version=154.0.8025.0
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=f596bc5cf668fe5e49df7820381d921b8763438e21cacd681ccbe7a9efe6f526
+checksum=71a35ac57f066bdf8b1bef1c718dc8873c13d6bd211029584c0865ec1ec1dc69
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=154.0.1.2
+version=154.0.1.3
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/154.0.1-2/librewolf-154.0.1-2-linux-x86_64-package.tar.xz"
-checksum=1d55e6a80952494ab88d84c999b1594b477b455d79b53066edc9f7cc3dfbbbc8
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/154.0.1-3/librewolf-154.0.1-3-linux-x86_64-package.tar.xz"
+checksum=413a71164ace86ceeaa426568b3196fe9fda823f873a106803e075dc4dbfdf5f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-08-28

### Updated packages
- firefox-nightly(157.0a1)
- google-chrome-dev(154.0.8025.0)
- librewolf(154.0.1.3)

### ⚠️ Failed updates
- amneziavpn
- ayugram
- bitwarden-bin
- brave
- bruno
- caprine
- chatbox
- chiaki-ng
- claude-desktop
- codewhale
- copyq
- cryptomator
- curlie
- darkly
- dbgate
- espflash
- ferdium
- floorp
- github-desktop
- handy-bin
- happ
- hck
- helium-browser
- heroic
- hiddify
- insomnia
- jnv
- kmon
- koala-clash
- kubeshark
- linutil
- localsend
- logitune
- losslesscut
- lpm
- macchina
- mouser-bin
- musescore-bin
- noctalia-shell
- noi-bin
- nuclei
- obsidian
- ollama
- onlyoffice-desktopeditors
- opencode
- opendeck
- openlogi
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.