### PR TITLE
auto-update:  brave(1.94.117) chatbox(1.23.0) dbgate(7.2.6) floorp(12.17.1) google-chrome(152.0.7977.75) happ(4.1.3) helium-browser(0.16.3.1) koala-clash(1.4.1) librewolf(155.0.1) lpm(20260902) noctalia-shell(5.0.0-beta.10) ollama(0.33.2) opencode(1.18.26) portainer(2.45.0) protonmail-bridge(3.26.0) slack-desktop(4.52.155) telegram-bin(7.1.4) v2rayn-bin(7.24.9) vscode-bin(1.135.0) zed(1.17.2) zen-browser(1.21.16)

### DIFF
--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.93.138
+version=1.94.117
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=8c4038e3956088cbf8f658a5e39e1a88b9f710478a8449c94d1c356d8bddc82c
+checksum=865ff352311c57ba4639b5198bc89e92a838a57bff44182e3b9bb3980913a84d
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/chatbox/template
+++ b/srcpkgs/chatbox/template
@@ -1,6 +1,6 @@
 # Template file for 'chatbox'
 pkgname=chatbox
-version=1.22.3
+version=1.23.0
 revision=1
 archs="x86_64"
 wrksrc="chatbox-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://chatboxai.app/"
 distfiles="https://download.chatboxai.app/releases/Chatbox-${version}-x86_64.AppImage"
-checksum=6ef9e3bee3cb4e19c771eb98c32f82db0b05cd9344834fdf3d5e7ef69e131013
+checksum=233bfc05b4ed3b56709abb1b1db18c5a3a2e2d3249f6a2438748f5971e77fb05
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/dbgate/template
+++ b/srcpkgs/dbgate/template
@@ -1,6 +1,6 @@
 # Template file for 'dbgate'
 pkgname=dbgate
-version=7.2.5
+version=7.2.6
 revision=1
 archs="x86_64"
 wrksrc="dbgate-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://dbgate.org/"
 distfiles="https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-linux_amd64.deb"
-checksum=00dfb10213cb596ee7489b415bcd0c98f3bbf1809cd62bb117394721686cfab8
+checksum=2936cccd459cfcacdb6e5425a13371ec2874314f6586ba278e3da37ff26606f3
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/floorp/template
+++ b/srcpkgs/floorp/template
@@ -1,6 +1,6 @@
 # Template file for 'floorp'
 pkgname=floorp
-version=12.17.0
+version=12.17.1
 revision=1
 archs="x86_64"
 wrksrc="floorp-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://floorp.app/"
 distfiles="https://github.com/Floorp-Projects/Floorp/releases/download/v${version}/floorp-${version}.deb"
-checksum=7aa1f4df38d991fb9bb8ebade488481fb784ff1efaa77c359e1aba44d88487b9
+checksum=560673b2ff1682f9a76eed4c32aa6bdee35b86c81c23e5e980c7cc4bc800fda7
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=152.0.7977.64
+version=152.0.7977.75
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=4eae0736a812d9bc851cd2937f7af00e47dbaf8305845eed452703ff009873c7
+checksum=a0b7a64f768ffc0ff5ccc9260ad9ebb53fd16f7a131e2e36994da58b82d913df
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/happ/template
+++ b/srcpkgs/happ/template
@@ -1,6 +1,6 @@
 # Template file for 'happ'
 pkgname=happ
-version=4.1.1
+version=4.1.3
 revision=1
 archs="x86_64"
 wrksrc="happ-${version}"
@@ -10,7 +10,7 @@ maintainer="Artem Kabanov <oloreas@gmail.com>"
 license="custom:Freeware"
 homepage="https://happ.su"
 distfiles="https://github.com/Happ-proxy/happ-desktop/releases/download/${version}/Happ.linux.x64.deb"
-checksum=2cf3fe06f132537263c96881a391cce48310aeec0748b6741a4357b0a62dcdb8
+checksum=32e543ec794bc365e609b4d4f758cf52bb313f063b97babb82899c209e9af022
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.15.7.1
+version=0.16.3.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=fb318419f848899584f265186f71eb92833bade14131d7d7960c372964f44fdf
+checksum=9370a3ac5e39b3b4a2cd1a1ffd7f5e3a73cac24381f5cd40bc14a68e3ed13883
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/koala-clash/template
+++ b/srcpkgs/koala-clash/template
@@ -1,6 +1,6 @@
 # Template file for 'koala-clash'
 pkgname=koala-clash
-version=1.4.0
+version=1.4.1
 revision=1
 archs="x86_64"
 wrksrc="koala-clash-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Proprietary"
 homepage="https://github.com/coolcoala/koala-clash"
 distfiles="https://github.com/coolcoala/koala-clash/releases/download/${version}/Koala.Clash_x86_64.rpm"
-checksum=2710137d3109701f6cf92bc8669111cc0db4068b3d25feb0fa7e2ac72437c61e
+checksum=e26d1351254d746e59dacb145f2752e4b47c15fa86f4018a0d2eeed19275dfa9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/librewolf/template
+++ b/srcpkgs/librewolf/template
@@ -1,6 +1,6 @@
 # Template file for 'librewolf'
 pkgname=librewolf
-version=154.0.1.3
+version=155.0.1
 revision=1
 archs="x86_64"
 wrksrc="librewolf-${version}"
@@ -12,8 +12,8 @@ homepage="https://librewolf.net/"
 
 _upver="${version%.*}-${version##*.}"
 
-distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/154.0.1-3/librewolf-154.0.1-3-linux-x86_64-package.tar.xz"
-checksum=413a71164ace86ceeaa426568b3196fe9fda823f873a106803e075dc4dbfdf5f
+distfiles="https://codeberg.org/api/packages/librewolf/generic/librewolf/155.0-1/librewolf-155.0-1-linux-x86_64-package.tar.xz"
+checksum=d7c45c5b1833f72cd497a91a314a465cec2d36713f63f884742d1165f7da0cdd
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/lpm/template
+++ b/srcpkgs/lpm/template
@@ -1,6 +1,6 @@
 # Template file for 'lpm'
 pkgname=lpm
-version=20260506
+version=20260902
 revision=1
 archs="x86_64"
 wrksrc="lpm-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/lite-xl/lite-xl-plugin-manager"
 distfiles="https://github.com/lite-xl/lite-xl-plugin-manager/releases/download/continuous/lpm.x86_64-linux"
-checksum=e290c17649b017d0530151d86fc537f1b2e32caee1b334c3dd3b9bfc51ae22f2
+checksum=6f31332425932e334e8bc20787a79170f83560f7c9fdd2e070ee167c2d2ed8d9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/noctalia-shell/template
+++ b/srcpkgs/noctalia-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'noctalia-shell'
 pkgname=noctalia-shell
-version=5.0.0-beta.9
+version=5.0.0-beta.10
 revision=1
 depends="noctalia-qs ImageMagick brightnessctl ffmpeg qt6-multimedia python3"
 short_desc="Sleek and minimal Wayland desktop shell built with Quickshell"
@@ -8,7 +8,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/noctalia-dev/noctalia-shell"
 distfiles="https://github.com/noctalia-dev/noctalia-shell/archive/refs/tags/v${version}.tar.gz"
-checksum=95173862a62ff36923212e9de6d58f789841acf147fea99d351fdbfae6a60eda
+checksum=6386f9b56bf01e6515a3df9e4662a80a8e20ec87815cdca362af9b9c3c429be2
 
 do_install() {
 	vmkdir etc/xdg/quickshell/noctalia-shell

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.33.0
+version=0.33.2
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=72c4b9d91c317742ffd11b92e0a7fbe6353072c6354d910f1a03fd3ce40403d4
+checksum=9785247dea264d9072f09f6c9c0eb4b8e666892826a3d8388eba3e8fb9ed1db9
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.23
+version=1.18.26
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
+checksum=7c20c1ffa91bcca0ac903752260bcc36307dff656833baead2f5ef3b224b16c6
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/portainer/template
+++ b/srcpkgs/portainer/template
@@ -1,6 +1,6 @@
 # Template file for 'portainer'
 pkgname=portainer
-version=2.39.6
+version=2.45.0
 revision=1
 archs="x86_64"
 wrksrc="portainer-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Zlib"
 homepage="https://www.portainer.io/"
 distfiles="https://github.com/portainer/portainer/releases/download/${version}/portainer-${version}-linux-amd64.tar.gz"
-checksum=dea18370b6f6815a2d06ba59edf6932eb40df4c6a808279e2415ba050c5d292a
+checksum=f560c7722ee0c6bd02b874afae634e369ca8479cdb36c2438e3461a714e49822
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,6 +1,6 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=3.25.0
+version=3.26.0
 revision=1
 archs="x86_64"
 wrksrc="protonmail-bridge-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://proton.me/mail/bridge"
 distfiles="https://github.com/ProtonMail/proton-bridge/releases/download/v${version}/protonmail-bridge_${version}-1_amd64.deb"
-checksum=6b0318f4f425ef1a19b63e2bd589bc1036d95f073cb9ac26b42c0fc63a8bc275
+checksum=c076872522ce2f0facd0e64764d7d588b3a1ed213ff3acd25386b51e8a1f02e8
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.51.180
+version=4.52.155
 revision=1
 archs="x86_64"
 wrksrc="slack-desktop-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Slack"
 homepage="https://slack.com/downloads"
 distfiles="https://downloads.slack-edge.com/desktop-releases/linux/x64/${version}/slack-desktop-${version}-amd64.deb"
-checksum=aa45e151794703377012a9ad78f0b2152c368852e085267ae689dafb5c308ea1
+checksum=966536026f5afcd1c75a395dddd87b9596580931f659b40cebb21ab3add71b2f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/telegram-bin/template
+++ b/srcpkgs/telegram-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'telegram-bin'
 pkgname=telegram-bin
-version=7.1.2
+version=7.1.4
 revision=1
 archs="x86_64"
 wrksrc="Telegram"
@@ -12,7 +12,7 @@ license="GPL-3.0-or-later"
 homepage="https://desktop.telegram.org"
 changelog="https://github.com/telegramdesktop/tdesktop/blob/v${version}/changelog.txt"
 distfiles="https://github.com/telegramdesktop/tdesktop/releases/download/v${version}/tsetup.${version}.tar.xz"
-checksum=0a62f115eeeebd23215461e496a046095c46c9c3d17884f5422148a23f41fe9d
+checksum=494c8245b129ef4a9887cacf827721791885f98d57f32459a8ce0c1bbaae3ebb
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/v2rayn-bin/template
+++ b/srcpkgs/v2rayn-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'v2rayn-bin'
 pkgname=v2rayn-bin
 _pkgname=v2rayN
-version=7.24.4
+version=7.24.9
 revision=1
 hostmakedepends="tar xz"
 short_desc="GUI client for v2ray that supports Xray, sing-box and others"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://v2rayn.2dust.link"
 distfiles="https://github.com/2dust/${_pkgname}/releases/download/${version}/${_pkgname}-linux-64.deb"
-checksum=e84ee82cbb2f2a9497235369489dbea6788b1c85f7f8d8331e5c31baec75739f
+checksum=8b8893fe951b98158dfe44cd12dd562f2914fad9350732c36b3d214c6fc8a4bc
 nostrip=yes
 noshlibs=yes
 nopie=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.134.0
+version=1.135.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=9336170079f527f1ca62dad39947b020db06bd3e8cae7e1e6097bea594f37733
+checksum=470f281e9d75f03b1b957f38e193580140de3b1d9c9ba6db13e7bf30aead4e00
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.16.1
+version=1.17.2
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=9e611add0c40e86b150372458a2d7b78d101c54924dc7bca8db27ce20d97c661
+checksum=3682dd058a305d2b246a14d64419fcf42e86a06e27755d23b5a28622ed9aef85
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zen-browser/template
+++ b/srcpkgs/zen-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.21.15
+version=1.21.16
 revision=1
 archs="x86_64"
 wrksrc="zen"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://github.com/zen-browser/desktop"
 distfiles="https://github.com/zen-browser/desktop/releases/download/${version}b/zen.linux-x86_64.tar.xz"
-checksum=2eaea664b840067ca0ace623bd4f4548fae98f46a98e2ddbdfdcb9253b674bbf
+checksum=1e4c3c391d10a82239d35afad84658fa3b3856b8ff72f93bbff7f57392acb942
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-09-02

### Updated packages
- brave(1.94.117)
- chatbox(1.23.0)
- dbgate(7.2.6)
- floorp(12.17.1)
- google-chrome(152.0.7977.75)
- happ(4.1.3)
- helium-browser(0.16.3.1)
- koala-clash(1.4.1)
- librewolf(155.0.1)
- lpm(20260902)
- noctalia-shell(5.0.0-beta.10)
- ollama(0.33.2)
- opencode(1.18.26)
- portainer(2.45.0)
- protonmail-bridge(3.26.0)
- slack-desktop(4.52.155)
- telegram-bin(7.1.4)
- v2rayn-bin(7.24.9)
- vscode-bin(1.135.0)
- zed(1.17.2)
- zen-browser(1.21.16)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- postman

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.