### PR TITLE
auto-update:  noctalia-shell(5.0.1) slack-desktop(4.52.155)

### DIFF
--- a/srcpkgs/noctalia-shell/template
+++ b/srcpkgs/noctalia-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'noctalia-shell'
 pkgname=noctalia-shell
-version=5.0.0-beta.9
+version=5.0.1
 revision=1
 depends="noctalia-qs ImageMagick brightnessctl ffmpeg qt6-multimedia python3"
 short_desc="Sleek and minimal Wayland desktop shell built with Quickshell"
@@ -8,7 +8,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/noctalia-dev/noctalia-shell"
 distfiles="https://github.com/noctalia-dev/noctalia-shell/archive/refs/tags/v${version}.tar.gz"
-checksum=95173862a62ff36923212e9de6d58f789841acf147fea99d351fdbfae6a60eda
+checksum=ed8334f294e9f94f4744e315b674511fc51203a6a56c561af8803a6eb6884698
 
 do_install() {
 	vmkdir etc/xdg/quickshell/noctalia-shell

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.51.180
+version=4.52.155
 revision=1
 archs="x86_64"
 wrksrc="slack-desktop-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Slack"
 homepage="https://slack.com/downloads"
 distfiles="https://downloads.slack-edge.com/desktop-releases/linux/x64/${version}/slack-desktop-${version}-amd64.deb"
-checksum=aa45e151794703377012a9ad78f0b2152c368852e085267ae689dafb5c308ea1
+checksum=966536026f5afcd1c75a395dddd87b9596580931f659b40cebb21ab3add71b2f
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-09-06

### Updated packages
- noctalia-shell(5.0.1)
- slack-desktop(4.52.155)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- opendeck
- openlogi
- openscreen
- peazip
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.