### PR TITLE
auto-update:  claude-desktop(1.46388.2) noctalia-shell(5.0.1)

### DIFF
--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.40609.1
-_release=3.2.3
+version=1.46388.2
+_release=3.2.4
 revision=1
 archs="x86_64"
 wrksrc="claude-desktop-${version}"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.3%2Bclaude1.40609.1/claude-desktop-unofficial-1.40609.1-3.2.3-amd64.AppImage"
-checksum=792d6e2ad8b155431d270e35e238c5dcaecd815d1b76728ca48496d628a89718
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.4%2Bclaude1.46388.2/claude-desktop-unofficial-1.46388.2-3.2.4-amd64.AppImage"
+checksum=a6548d00f4f0aacebdae1d7b3b4ed1c5212391d7e3cdb407e5dc5fb70579b51e
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/noctalia-shell/template
+++ b/srcpkgs/noctalia-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'noctalia-shell'
 pkgname=noctalia-shell
-version=5.0.0-beta.9
+version=5.0.1
 revision=1
 depends="noctalia-qs ImageMagick brightnessctl ffmpeg qt6-multimedia python3"
 short_desc="Sleek and minimal Wayland desktop shell built with Quickshell"
@@ -8,7 +8,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/noctalia-dev/noctalia-shell"
 distfiles="https://github.com/noctalia-dev/noctalia-shell/archive/refs/tags/v${version}.tar.gz"
-checksum=95173862a62ff36923212e9de6d58f789841acf147fea99d351fdbfae6a60eda
+checksum=ed8334f294e9f94f4744e315b674511fc51203a6a56c561af8803a6eb6884698
 
 do_install() {
 	vmkdir etc/xdg/quickshell/noctalia-shell


### PR DESCRIPTION
## Automated package updates — 2026-09-07

### Updated packages
- claude-desktop(1.46388.2)
- noctalia-shell(5.0.1)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- postman
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.