### PR TITLE
auto-update:  ferdium(7.2.3) happ(4.2.1) noctalia-shell(5.0.1)

### DIFF
--- a/srcpkgs/ferdium/template
+++ b/srcpkgs/ferdium/template
@@ -1,6 +1,6 @@
 # Template file for 'ferdium'
 pkgname=ferdium
-version=7.2.2
+version=7.2.3
 revision=1
 archs="x86_64"
 wrksrc="ferdium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://ferdium.org/"
 distfiles="https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-amd64.deb"
-checksum=cd325656fec21c41f74e0d5b0eaa7107e2a2adaa258b58d3bd0f615e7dcc3960
+checksum=f8a3f5d3b6bc4e6af6a91f291fe807b97a84aa20b91313c65e860ea95d54adba
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/happ/template
+++ b/srcpkgs/happ/template
@@ -1,6 +1,6 @@
 # Template file for 'happ'
 pkgname=happ
-version=4.1.3
+version=4.2.1
 revision=1
 archs="x86_64"
 wrksrc="happ-${version}"
@@ -10,7 +10,7 @@ maintainer="Artem Kabanov <oloreas@gmail.com>"
 license="custom:Freeware"
 homepage="https://happ.su"
 distfiles="https://github.com/Happ-proxy/happ-desktop/releases/download/${version}/Happ.linux.x64.deb"
-checksum=32e543ec794bc365e609b4d4f758cf52bb313f063b97babb82899c209e9af022
+checksum=bc8bc0bd61f8fd96e5c58117ced85cdb0adc3c28a703e7965ecdff108954ae75
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/noctalia-shell/template
+++ b/srcpkgs/noctalia-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'noctalia-shell'
 pkgname=noctalia-shell
-version=5.0.0-beta.9
+version=5.0.1
 revision=1
 depends="noctalia-qs ImageMagick brightnessctl ffmpeg qt6-multimedia python3"
 short_desc="Sleek and minimal Wayland desktop shell built with Quickshell"
@@ -8,7 +8,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/noctalia-dev/noctalia-shell"
 distfiles="https://github.com/noctalia-dev/noctalia-shell/archive/refs/tags/v${version}.tar.gz"
-checksum=95173862a62ff36923212e9de6d58f789841acf147fea99d351fdbfae6a60eda
+checksum=ed8334f294e9f94f4744e315b674511fc51203a6a56c561af8803a6eb6884698
 
 do_install() {
 	vmkdir etc/xdg/quickshell/noctalia-shell


### PR DESCRIPTION
## Automated package updates — 2026-09-08

### Updated packages
- ferdium(7.2.3)
- happ(4.2.1)
- noctalia-shell(5.0.1)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- portainer
- postman
- protonmail-bridge
- protonup-qt
- runkit
- rustdesk
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.