### PR TITLE
auto-update:  arianna(26.08.1) chatbox(1.23.2) claude-desktop(1.49585.0) ferdium(7.2.3) google-chrome(153.0.8010.36) happ(4.2.1) helium-browser(0.16.6.1) musescore-bin(4.7.5.260831071) ollama(0.34.0) opencode(1.18.30) tg-ws-proxy(1.10.2) vscode-bin(1.137.0) zapret2(1.0.5.1) zed(1.19.2)

### DIFF
--- a/srcpkgs/arianna/template
+++ b/srcpkgs/arianna/template
@@ -1,6 +1,6 @@
 # Template file for 'arianna'
 pkgname=arianna
-version=26.08.0
+version=26.08.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -18,6 +18,6 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://apps.kde.org/arianna/"
 distfiles="https://download.kde.org/stable/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=c39b09785b0f5ec882451e14010e09078e5797483fd5293c2dfd259573ac5f95
+checksum=affa1f27d97608bad8ab0871ca06906d47127c0731bd4759f975e7e59cd1ff00
 noverifyrdeps=yes
 disable_shlib_provides=yes

--- a/srcpkgs/chatbox/template
+++ b/srcpkgs/chatbox/template
@@ -1,6 +1,6 @@
 # Template file for 'chatbox'
 pkgname=chatbox
-version=1.23.1
+version=1.23.2
 revision=1
 archs="x86_64"
 wrksrc="chatbox-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://chatboxai.app/"
 distfiles="https://download.chatboxai.app/releases/Chatbox-${version}-x86_64.AppImage"
-checksum=b92c9a50b5f9594a914e7174ced75d1fce3e3380b5a6f836033a2d47b7333cc5
+checksum=5e9c90ee5612bfdb2f6180b7d672a3fcc6a79fe23f391527390ea22ae6998bfc
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.46388.2
+version=1.49585.0
 _release=3.2.4
 revision=1
 archs="x86_64"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.4%2Bclaude1.46388.2/claude-desktop-unofficial-1.46388.2-3.2.4-amd64.AppImage"
-checksum=a6548d00f4f0aacebdae1d7b3b4ed1c5212391d7e3cdb407e5dc5fb70579b51e
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.4%2Bclaude1.49585.0/claude-desktop-unofficial-1.49585.0-3.2.4-amd64.AppImage"
+checksum=9384fdaec62ad01197b8b2dfdd9a02c90cd1ac70c1648499f8b83ba7ba446997
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/ferdium/template
+++ b/srcpkgs/ferdium/template
@@ -1,6 +1,6 @@
 # Template file for 'ferdium'
 pkgname=ferdium
-version=7.2.2
+version=7.2.3
 revision=1
 archs="x86_64"
 wrksrc="ferdium-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="Apache-2.0"
 homepage="https://ferdium.org/"
 distfiles="https://github.com/ferdium/ferdium-app/releases/download/v${version}/Ferdium-linux-${version}-amd64.deb"
-checksum=cd325656fec21c41f74e0d5b0eaa7107e2a2adaa258b58d3bd0f615e7dcc3960
+checksum=f8a3f5d3b6bc4e6af6a91f291fe807b97a84aa20b91313c65e860ea95d54adba
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=152.0.7977.82
+version=153.0.8010.36
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}-1_amd64.deb"
-checksum=4d25e4a028c78a7ae910683551c2f234792cc5595e7e3e34939f599342ada446
+checksum=9bb44e33031c2f2857cf36b4343051a12f93058e4b781e3c76313df87f6c8d32
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/happ/template
+++ b/srcpkgs/happ/template
@@ -1,6 +1,6 @@
 # Template file for 'happ'
 pkgname=happ
-version=4.1.3
+version=4.2.1
 revision=1
 archs="x86_64"
 wrksrc="happ-${version}"
@@ -10,7 +10,7 @@ maintainer="Artem Kabanov <oloreas@gmail.com>"
 license="custom:Freeware"
 homepage="https://happ.su"
 distfiles="https://github.com/Happ-proxy/happ-desktop/releases/download/${version}/Happ.linux.x64.deb"
-checksum=32e543ec794bc365e609b4d4f758cf52bb313f063b97babb82899c209e9af022
+checksum=bc8bc0bd61f8fd96e5c58117ced85cdb0adc3c28a703e7965ecdff108954ae75
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.16.5.1
+version=0.16.6.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=37afb0c20e3ab9fb1b0aa109bff5a94d60c29c8ded9c5b79f1c1ba4ec1b15dec
+checksum=4f6f5ee50a57b056000ef4ac35cb62d8b5ea2da0948c1e662d81271eda713bf4
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"

--- a/srcpkgs/musescore-bin/template
+++ b/srcpkgs/musescore-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'musescore-bin'
 pkgname=musescore-bin
-version=4.7.4.260706075
+version=4.7.5.260831071
 revision=1
 archs="x86_64"
 wrksrc="musescore-${version}"
@@ -9,8 +9,8 @@ short_desc="Music notation and composition software (AppImage repack)"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://musescore.org/"
-distfiles="https://github.com/musescore/MuseScore/releases/download/v4.7.4/MuseScore-Studio-4.7.4.260706075-x86_64.AppImage"
-checksum=9233ed1b87d3e6b45722278f3c286dcd41e83da778bd0f80a1dd04949696ad93
+distfiles="https://github.com/musescore/MuseScore/releases/download/v4.7.5/MuseScore-Studio-4.7.5.260831071-x86_64.AppImage"
+checksum=a31b2da2dbcc2191bcc98beb7be5c15f2f517bedb3444def96fe3088b74d3a1e
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/ollama/template
+++ b/srcpkgs/ollama/template
@@ -1,6 +1,6 @@
 # Template file for 'ollama'
 pkgname=ollama
-version=0.33.3
+version=0.34.0
 revision=1
 archs="x86_64"
 wrksrc="ollama-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://ollama.com/"
 distfiles="https://github.com/ollama/ollama/releases/download/v${version}/ollama-linux-amd64.tar.zst"
-checksum=c13cea8f3389db4145f8a6cb88d1747242a48639d7c13e3bda7c1ebdc6eebb2f
+checksum=cf95886728959aa09910bb34de5cca1cc5a8f68003b5597197d3f2c2d57c0804
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/opencode/template
+++ b/srcpkgs/opencode/template
@@ -1,12 +1,12 @@
 # Template file for 'opencode'
 pkgname=opencode
-version=1.18.29
+version=1.18.30
 revision=1
 archs="x86_64"
 wrksrc="opencode-${version}"
 hostmakedepends="tar"
 distfiles="https://github.com/anomalyco/opencode/releases/download/v${version}/opencode-linux-x64.tar.gz"
-checksum=ea800b7ff56226b70952126c9fc1e2517ca4c4b5682fd9d3f9e87449697a1194
+checksum=55007246858165496ff85ba1c2b648f7421e8e2013bf4189a680c9ff8e699d17
 homepage="https://github.com/anomalyco/opencode"
 license="MIT"
 short_desc="Open source AI coding agent (CLI/TUI version)"

--- a/srcpkgs/tg-ws-proxy/template
+++ b/srcpkgs/tg-ws-proxy/template
@@ -1,6 +1,6 @@
 # Template file for 'tg-ws-proxy'
 pkgname=tg-ws-proxy
-version=1.10.1
+version=1.10.2
 revision=1
 archs="x86_64"
 wrksrc="tg-ws-proxy-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/Flowseal/tg-ws-proxy"
 distfiles="https://github.com/Flowseal/tg-ws-proxy/releases/download/v${version}/TgWsProxy_linux_amd64.deb"
-checksum=c36aaf88814b0ef71c6486cf2206efe1fe78188fc3aa5357962eed150c3a6694
+checksum=0459b3d75503276f3c5e925393f60c6f9a42fd25e49fea6902cd9c3bd96c0061
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/vscode-bin/template
+++ b/srcpkgs/vscode-bin/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode-bin'
 pkgname=vscode-bin
-version=1.136.1
+version=1.137.0
 revision=1
 archs="x86_64"
 wrksrc="VSCode-linux-x64"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Microsoft-EULA"
 homepage="https://code.visualstudio.com"
 distfiles="https://update.code.visualstudio.com/${version}/linux-x64/stable>code-${version}.tar.gz"
-checksum=9b4a54f0d49beaa413eda137d00c6541a639300d479efcac566ad13419409218
+checksum=8871d637292568e34c2d27daa5320a3b3c805f41f94014dfceafbe6134187fce
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/zapret2/template
+++ b/srcpkgs/zapret2/template
@@ -1,6 +1,6 @@
 # Template file for 'zapret2'
 pkgname=zapret2
-version=1.0.5
+version=1.0.5.1
 revision=1
 build_style=gnu-makefile
 makedepends="LuaJIT-devel libcap-devel zlib-devel libnetfilter_queue-devel"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/bol-van/zapret2"
 distfiles="https://github.com/bol-van/zapret2/archive/refs/tags/v${version}.tar.gz"
-checksum=f20965e7fd6df2544a787055995dbd6e5a7c95ae12eb6ca57af3527d45767a1f
+checksum=22996f2af7b9a091139dec190fabdb2cd5bf918d3da51b0dfad7b44df9d3d461
 
 do_prepare() {
     cd ipset

--- a/srcpkgs/zed/template
+++ b/srcpkgs/zed/template
@@ -1,6 +1,6 @@
 # Template file for 'zed'
 pkgname=zed
-version=1.18.1
+version=1.19.2
 revision=1
 archs="x86_64"
 wrksrc="zed.app"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://zed.dev/"
 distfiles="https://github.com/zed-industries/zed/releases/download/v${version}/zed-linux-x86_64.tar.gz"
-checksum=eea62268d8ec5fd3587df06fa76e072c104cca5e0b0b0abecbc28ae5b87c0bad
+checksum=c5acff2e52ac3c64890cce85250734cf7279c1de56d5926e4f4e1d4cf676359c
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes


### PR DESCRIPTION
## Automated package updates — 2026-09-10

### Updated packages
- arianna(26.08.1)
- chatbox(1.23.2)
- claude-desktop(1.49585.0)
- ferdium(7.2.3)
- google-chrome(153.0.8010.36)
- happ(4.2.1)
- helium-browser(0.16.6.1)
- musescore-bin(4.7.5.260831071)
- ollama(0.34.0)
- opencode(1.18.30)
- tg-ws-proxy(1.10.2)
- vscode-bin(1.137.0)
- zapret2(1.0.5.1)
- zed(1.19.2)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- postman
- telegram-bin

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.