### PR TITLE
auto-update:  antigravity-cli(1.2.0.5210873191596032) espflash(4.6.0) firefox-nightly(158.0a1) google-chrome-dev(155.0.8048.0) noctalia(5.1.0)

### DIFF
--- a/srcpkgs/antigravity-cli/template
+++ b/srcpkgs/antigravity-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'antigravity-cli'
 pkgname=antigravity-cli
-version=1.1.27.5211191891591168
+version=1.2.0.5210873191596032
 revision=1
 archs="x86_64"
 wrksrc="antigravity-cli-${version}"
@@ -9,9 +9,9 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:proprietary"
 homepage="https://antigravity.google/product/antigravity-cli"
 depends="glibc"
-_upstream_version="1.1.27-5211191891591168"
+_upstream_version=1.2.0-5210873191596032
 distfiles="https://storage.googleapis.com/antigravity-public/antigravity-cli/${_upstream_version}/linux-x64/cli_linux_x64.tar.gz"
-checksum=f874d4f6b8a73c2df660f580f25fb656fcb6e64adbfd746e6692e837fd9a20be
+checksum=d9bfee1ae6e4329562cb87da1f5fc3c886d18594837e73e25c3aae00a49499b9
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/espflash/template
+++ b/srcpkgs/espflash/template
@@ -1,6 +1,6 @@
 # Template file for 'espflash'
 pkgname=espflash
-version=4.5.0
+version=4.6.0
 revision=1
 archs="x86_64"
 wrksrc="espflash-${version}"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/esp-rs/espflash"
 distfiles="https://github.com/esp-rs/espflash/releases/download/v${version}/espflash-x86_64-unknown-linux-gnu.zip"
-checksum=dcd7fd822f247df18966935bbb10c7cb4b700c87172349633e9e323ee2542717
+checksum=c4fcfa32ddc3155608f003a230e6f3c184eff9641ec9cfa8eb54f1b515d403e7
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/firefox-nightly/template
+++ b/srcpkgs/firefox-nightly/template
@@ -1,6 +1,6 @@
 # Template file for 'firefox-nightly'
 pkgname=firefox-nightly
-version=157.0a1
+version=158.0a1
 revision=1
 archs="x86_64"
 wrksrc="firefox"
@@ -10,7 +10,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/firefox/channel/desktop/#nightly"
 distfiles="https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US"
-checksum=02d5338a073ea5c6eeb69dc17a4d878fcf55c6d41ab7d34b806ae6589dc9bd28
+checksum=b2f4ec8d74749a02ec10e93d76f83eaf0fdb2ad53a34b62409e67fee7c2a3d71
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/google-chrome-dev/template
+++ b/srcpkgs/google-chrome-dev/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome-dev'
 pkgname=google-chrome-dev
-version=155.0.8040.2
+version=155.0.8048.0
 revision=1
 archs="x86_64"
 wrksrc="google-chrome-dev-${version}"
@@ -9,7 +9,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:chrome"
 homepage="https://www.google.com/chrome"
 distfiles="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_${version}-1_amd64.deb"
-checksum=30a3262856e9c733e97216b5476be41108494bfa7bff3ab12b9e2e575052fe71
+checksum=9afc139c9f898d5996251722ffedcee6c8515f4bae12054ed343f4575b06b3f0
 nostrip=yes
 noshlibs=yes
 noverifyrdeps=yes

--- a/srcpkgs/noctalia/template
+++ b/srcpkgs/noctalia/template
@@ -1,8 +1,8 @@
 # Template file for 'akira-noctalia'
 pkgname=noctalia
-version=5.0.1
+version=5.1.0
 revision=1
-_tag=5.0.1
+_tag=5.1.0
 wrksrc="noctalia-${_tag}"
 build_style=meson
 hostmakedepends="pkg-config scdoc cmake"
@@ -18,7 +18,7 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="MIT"
 homepage="https://github.com/noctalia-dev/noctalia"
 distfiles="https://github.com/noctalia-dev/noctalia/archive/refs/tags/v${_tag}.tar.gz"
-checksum=ed8334f294e9f94f4744e315b674511fc51203a6a56c561af8803a6eb6884698
+checksum=fcf37d99ecb6093b38df8f0d6a18012f518895cd8d3934fd16164a7d0b7b3062
 
 post_install() {
     vlicense LICENSE


### PR DESCRIPTION
## Automated package updates — 2026-09-11

### Updated packages
- antigravity-cli(1.2.0.5210873191596032)
- espflash(4.6.0)
- firefox-nightly(158.0a1)
- google-chrome-dev(155.0.8048.0)
- noctalia(5.1.0)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- postman
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.