### PR TITLE
auto-update:  antigravity-cli(1.2.1.5123043593420800) brave(1.95.101) claude-desktop(1.52386.3) helium-browser(0.17.0.1)

### DIFF
--- a/srcpkgs/antigravity-cli/template
+++ b/srcpkgs/antigravity-cli/template
@@ -1,6 +1,6 @@
 # Template file for 'antigravity-cli'
 pkgname=antigravity-cli
-version=1.2.0.5210873191596032
+version=1.2.1.5123043593420800
 revision=1
 archs="x86_64"
 wrksrc="antigravity-cli-${version}"
@@ -9,9 +9,9 @@ maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:proprietary"
 homepage="https://antigravity.google/product/antigravity-cli"
 depends="glibc"
-_upstream_version=1.2.0-5210873191596032
+_upstream_version=1.2.1-5123043593420800
 distfiles="https://storage.googleapis.com/antigravity-public/antigravity-cli/${_upstream_version}/linux-x64/cli_linux_x64.tar.gz"
-checksum=d9bfee1ae6e4329562cb87da1f5fc3c886d18594837e73e25c3aae00a49499b9
+checksum=6a2c53db6c681fc114f9a1e499e7b4771357ab2852242e56acbd43197d4807f9
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/brave/template
+++ b/srcpkgs/brave/template
@@ -1,6 +1,6 @@
 # Template file for 'brave'
 pkgname=brave
-version=1.94.121
+version=1.95.101
 revision=1
 archs="x86_64"
 wrksrc="."
@@ -10,7 +10,7 @@ short_desc="Web browser that blocks ads and trackers by default"
 license="MPL-2.0"
 homepage="https://brave.com"
 distfiles="https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser-${version}-linux-amd64.zip>brave-${version}-linux-amd64.zip"
-checksum=33a0c940037d97844c1848907b81de4418b98d07287f46220d07d88543b8a4b5
+checksum=d30e9e1206074c0f24ad0eca1ca44b9a3abcde05a837074ec9045c8e599b6733
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/claude-desktop/template
+++ b/srcpkgs/claude-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'claude-desktop'
 pkgname=claude-desktop
-version=1.49585.0
+version=1.52386.3
 _release=3.2.4
 revision=1
 archs="x86_64"
@@ -11,8 +11,8 @@ short_desc="Claude Desktop native Linux client for Claude AI"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 license="custom:Anthropic-TOS"
 homepage="https://github.com/aaddrick/claude-desktop-debian"
-distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.4%2Bclaude1.49585.0/claude-desktop-unofficial-1.49585.0-3.2.4-amd64.AppImage"
-checksum=9384fdaec62ad01197b8b2dfdd9a02c90cd1ac70c1648499f8b83ba7ba446997
+distfiles="https://github.com/aaddrick/claude-desktop-debian/releases/download/v3.2.4%2Bclaude1.52386.3/claude-desktop-unofficial-1.52386.3-3.2.4-amd64.AppImage"
+checksum=5647ee65d8a017ae2b92a986618b8a021e24bc027f1766770a700796d7e5a2ba
 nostrip=yes
 noshlibs=yes
 

--- a/srcpkgs/helium-browser/template
+++ b/srcpkgs/helium-browser/template
@@ -1,6 +1,6 @@
 # Template file for 'helium-browser'
 pkgname=helium-browser
-version=0.16.6.1
+version=0.17.0.1
 revision=1
 archs="x86_64"
 wrksrc="helium-${version}"
@@ -10,7 +10,7 @@ license="GPL-3.0-only"
 maintainer="cybarchitect <cybarchitect@gmail.com>"
 homepage="https://github.com/imputnet/helium"
 distfiles="https://github.com/imputnet/helium-linux/releases/download/${version}/helium-${version}-x86_64.AppImage>helium-${version}.AppImage"
-checksum=4f6f5ee50a57b056000ef4ac35cb62d8b5ea2da0948c1e662d81271eda713bf4
+checksum=266a9d130a173ffd86180312da08c0abb1b6a1616ec944ebe68b8c0e148e7076
 nostrip=yes
 noshlibs=yes
 ignored_shlibs="libvulkan.so.1"


### PR DESCRIPTION
## Automated package updates — 2026-09-12

### Updated packages
- antigravity-cli(1.2.1.5123043593420800)
- brave(1.95.101)
- claude-desktop(1.52386.3)
- helium-browser(0.17.0.1)

### ⚠️ Failed updates
- amneziavpn
- obsidian
- postman
- scope-tui
- simplex-desktop
- superfile
- tabby
- telegram-bin
- tg-ws-proxy
- thorium-browser
- ttf-jetbrains-mono
- v2rayn-bin
- ventoy
- vfox
- vscode-bin
- wild-linker
- ytfzf
- zapret2
- zed
- zen-browser

This PR was created automatically by the update workflow.
After merging, the build workflow will automatically build and deploy updated packages.